### PR TITLE
fix: added more detailed error message for 409 workspace template to …

### DIFF
--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -611,7 +611,11 @@ func (c *Client) CreateWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 		return nil, err
 	}
 	if existingWorkspaceTemplate != nil {
-		return nil, util.NewUserError(codes.AlreadyExists, "Workspace template already exists.")
+		message := fmt.Sprintf("Workspace template with the name '%v' already exists", workspaceTemplate.Name)
+		if existingWorkspaceTemplate.IsArchived {
+			message = fmt.Sprintf("An archived workspace template with the name '%v' already exists", workspaceTemplate.Name)
+		}
+		return nil, util.NewUserError(codes.AlreadyExists, message)
 	}
 
 	workspaceTemplate.WorkflowTemplate, err = c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate)

--- a/pkg/workspace_template_types.go
+++ b/pkg/workspace_template_types.go
@@ -10,7 +10,7 @@ type WorkspaceTemplate struct {
 	UID                        string
 	CreatedAt                  time.Time  `db:"created_at"`
 	ModifiedAt                 *time.Time `db:"modified_at"`
-	IsArchived                 string     `db:"is_archived"`
+	IsArchived                 bool       `db:"is_archived"`
 	Name                       string     `valid:"stringlength(3|30)~Name should be between 3 to 30 characters,required"`
 	Namespace                  string
 	Version                    int64


### PR DESCRIPTION
…distinguish between archived workspace taking the name, or another template.

Also changed IsArchived to be a bool type instead of string for workspace template type, as that's what it is in the database.

Fixes an issue in onepanelio/core#214 