### PR TITLE
feat: add cvat migration template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ COPY . .
 
 RUN go get -d -v ./...
 RUN go install -v ./...
-
+RUN go get -u github.com/pressly/goose/cmd/goose
+RUN go build -o /go/bin/goose ./cmd/goose.go
 
 FROM golang:1.13.10
 COPY --from=builder /go/bin/core .
 COPY --from=builder /go/src/db ./db
+COPY --from=builder /go/bin/goose .
 
 EXPOSE 8888
 EXPOSE 8887

--- a/cmd/goose.go
+++ b/cmd/goose.go
@@ -1,0 +1,56 @@
+// This is custom goose binary to support .go migration files in ./db dir
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/onepanelio/core/db"
+	v1 "github.com/onepanelio/core/pkg"
+	"log"
+	"os"
+
+	"github.com/pressly/goose"
+)
+
+var (
+	flags = flag.NewFlagSet("goose", flag.ExitOnError)
+	dir   = flags.String("dir", ".", "directory with migration files")
+)
+
+func main() {
+	flags.Parse(os.Args[1:])
+	args := flags.Args()
+
+	if len(args) < 1 {
+		flags.Usage()
+		return
+	}
+
+	kubeConfig := v1.NewConfig()
+	client, err := v1.NewClient(kubeConfig, nil)
+	if err != nil {
+		log.Fatalf("Failed to connect to Kubernetes cluster: %v", err)
+	}
+	config, err := client.GetSystemConfig()
+	if err != nil {
+		log.Fatalf("Failed to get system config: %v", err)
+	}
+
+	databaseDataSourceName := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=disable",
+		config["databaseHost"], config["databaseUsername"], config["databasePassword"], config["databaseName"])
+
+	db := sqlx.MustConnect(config["databaseDriverName"], databaseDataSourceName)
+
+	command := args[0]
+
+	arguments := []string{}
+	if len(args) > 2 {
+		arguments = append(arguments, args[2:]...)
+	}
+
+	if err := goose.Run(command, db.DB, *dir, arguments...); err != nil {
+		log.Fatalf("goose %v: %v", command, err)
+	}
+}

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -1,3 +1,5 @@
+// Package migration is for carrying out migrations against the database.
+// To support Onepanel Core operations.
 package migration
 
 import (

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -90,7 +90,7 @@ func Up20200525160514(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkspaceTemplate(namespace.Name, workspaceTemplate); err != nil {
-			log.Printf("error %v", err.Error())
+			log.Fatalf("error %v", err.Error())
 		}
 	}
 
@@ -113,7 +113,7 @@ func Down20200525160514(tx *sql.Tx) error {
 	}
 	for _, namespace := range namespaces {
 		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, uid); err != nil {
-			log.Printf("error %v", err.Error())
+			log.Fatalf("error %v", err.Error())
 		}
 	}
 

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -108,7 +108,7 @@ func Down20200525160514(tx *sql.Tx) error {
 	}
 
 	for _, namespace := range namespaces {
-		if err := client.DeleteWorkspace(namespace.Name, jupyterLabTemplateName); err != nil {
+		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, jupyterLabTemplateName); err != nil {
 			log.Printf("error %v", err.Error())
 		}
 	}

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -49,22 +49,23 @@ routes:
       port:
         number: 80
 # DAG Workflow to be executed once a Workspace action completes
-postExecutionWorkflow:
-  entrypoint: main
-  templates:
-  - name: main
-    dag:
-       tasks:
-       - name: slack-notify
-         template: slack-notify
-  -  name: slack-notify
-     container:
-       image: technosophos/slack-notify
-       args:
-       - SLACK_USERNAME=onepanel SLACK_TITLE="Your workspace is ready" SLACK_ICON=https://www.gravatar.com/avatar/5c4478592fe00878f62f0027be59c1bd SLACK_MESSAGE="Your workspace is now running" ./slack-notify
-       command:
-       - sh
-       - -c`
+# postExecutionWorkflow:
+#   entrypoint: main
+#   templates:
+#   - name: main
+#     dag:
+#        tasks:
+#        - name: slack-notify
+#          template: slack-notify
+#   -  name: slack-notify
+#      container:
+#        image: technosophos/slack-notify
+#        args:
+#        - SLACK_USERNAME=onepanel SLACK_TITLE="Your workspace is ready" SLACK_ICON=https://www.gravatar.com/avatar/5c4478592fe00878f62f0027be59c1bd SLACK_MESSAGE="Your workspace is now running" ./slack-notify
+#        command:
+#        - sh
+#        - -c
+`
 
 const jupyterLabTemplateName = "JupyterLab"
 

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"database/sql"
 	v1 "github.com/onepanelio/core/pkg"
+	uid2 "github.com/onepanelio/core/pkg/util/uid"
 	"github.com/pressly/goose"
 	"log"
 )
@@ -106,9 +107,12 @@ func Down20200525160514(tx *sql.Tx) error {
 	if err != nil {
 		return err
 	}
-
+	uid, err := uid2.GenerateUID(jupyterLabTemplateName, 30)
+	if err != nil {
+		return err
+	}
 	for _, namespace := range namespaces {
-		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, jupyterLabTemplateName); err != nil {
+		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, uid); err != nil {
 			log.Printf("error %v", err.Error())
 		}
 	}

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -108,7 +108,7 @@ postExecutionWorkflow:
        - -c
 `
 
-const cvatTemplateName = "cvat"
+const cvatTemplateName = "CVAT"
 
 func init() {
 	goose.AddMigration(Up20200528140124, Down20200528140124)

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -32,7 +32,7 @@ containers:
   - containerPort: 6379
     name: tcp
 - name: cvat
-  image: onepanel/cvat:v0.6.23
+  image: onepanel/cvat:v0.6.24
   command: ["/bin/bash", "-c"]
   args: ["/usr/bin/supervisord && /usr/bin/python3 ~/manage.py shell --command='import os;from django.contrib.auth.models import User;u = User(username=os.getenv('DJANGO_SUPERUSER_USERNAME','admin'));u.set_password(os.getenv('DJANGO_SUPERUSER_PASSWORD','admin'));u.is_superuser = True;u.is_staff = True;u.save();'"]
   env:
@@ -59,7 +59,7 @@ containers:
   - name: models
     mountPath: /home/django/models
 - name: cvat-ui
-  image: onepanel/cvat-ui:v0.6.23
+  image: onepanel/cvat-ui:v0.6.24
   ports:
   - containerPort: 80
     name: http

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -155,7 +155,7 @@ func Down20200528140124(tx *sql.Tx) error {
 	}
 
 	for _, namespace := range namespaces {
-		if err := client.DeleteWorkspace(namespace.Name, cvatTemplateName); err != nil {
+		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, cvatTemplateName); err != nil {
 			log.Printf("error %v", err.Error())
 		}
 	}

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -116,7 +116,6 @@ func init() {
 
 func Up20200528140124(tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
-	//time.Sleep(2 * time.Second)
 
 	client, err := getClient()
 	if err != nil {

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -114,6 +114,9 @@ func init() {
 	goose.AddMigration(Up20200528140124, Down20200528140124)
 }
 
+// Up20200528140124 will insert the cvatTemplate to each user.
+// Each user is determined by onepanel enabled namespaces.
+// Any errors reported are logged as fatal.
 func Up20200528140124(tx *sql.Tx) error {
 	// This code is executed when the migration is applied.
 
@@ -141,6 +144,11 @@ func Up20200528140124(tx *sql.Tx) error {
 	return nil
 }
 
+// Down20200528140124 will attempt to remove cvatTemplate from each user.
+// Each user is determined by onepanel enabled namespaces.
+// DB entries are archived, K8S components are deleted.
+// Active workspaces with that template are terminated.
+// Any errors reported are logged as fatal.
 func Down20200528140124(tx *sql.Tx) error {
 	// This code is executed when the migration is rolled back.
 

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -135,7 +135,7 @@ func Up20200528140124(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkspaceTemplate(namespace.Name, workspaceTemplate); err != nil {
-			log.Printf("error %v", err.Error())
+			log.Fatalf("error %v", err.Error())
 		}
 	}
 
@@ -161,7 +161,7 @@ func Down20200528140124(tx *sql.Tx) error {
 	}
 	for _, namespace := range namespaces {
 		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, uid); err != nil {
-			log.Printf("error %v", err.Error())
+			log.Fatalf("error %v", err.Error())
 		}
 	}
 

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -33,9 +33,7 @@ containers:
   - containerPort: 6379
     name: tcp
 - name: cvat
-  image: onepanel/cvat:v0.6.24
-  command: ["/bin/bash", "-c"]
-  args: ["/usr/bin/supervisord && /usr/bin/python3 ~/manage.py shell --command='import os;from django.contrib.auth.models import User;u = User(username=os.getenv('DJANGO_SUPERUSER_USERNAME','admin'));u.set_password(os.getenv('DJANGO_SUPERUSER_PASSWORD','admin'));u.is_superuser = True;u.is_staff = True;u.save();'"]
+  image: onepanel/cvat:v0.7.0
   env:
   - name: DJANGO_MODWSGI_EXTRA_ARGS
     value: ""
@@ -60,7 +58,7 @@ containers:
   - name: models
     mountPath: /home/django/models
 - name: cvat-ui
-  image: onepanel/cvat-ui:v0.6.24
+  image: onepanel/cvat-ui:v0.7.0
   ports:
   - containerPort: 80
     name: http
@@ -91,22 +89,23 @@ routes:
   - destination:
       port:
         number: 80
-postExecutionWorkflow:
-  entrypoint: main
-  templates:
-  - name: main
-    dag:
-       tasks:
-       - name: slack-notify
-         template: slack-notify
-  -  name: slack-notify
-     container:
-       image: technosophos/slack-notify
-       args:
-       - SLACK_USERNAME=onepanel SLACK_TITLE="Your workspace is ready" SLACK_ICON=https://www.gravatar.com/avatar/5c4478592fe00878f62f0027be59c1bd SLACK_MESSAGE="Your workspace is now running" ./slack-notify
-       command:
-       - sh
-       - -c
+# DAG Workflow to be executed once a Workspace action completes
+# postExecutionWorkflow:
+#   entrypoint: main
+#   templates:
+#   - name: main
+#     dag:
+#        tasks:
+#        - name: slack-notify
+#          template: slack-notify
+#   -  name: slack-notify
+#      container:
+#        image: technosophos/slack-notify
+#        args:
+#        - SLACK_USERNAME=onepanel SLACK_TITLE="Your workspace is ready" SLACK_ICON=https://www.gravatar.com/avatar/5c4478592fe00878f62f0027be59c1bd SLACK_MESSAGE="Your workspace is now running" ./slack-notify
+#        command:
+#        - sh
+#        - -c
 `
 
 const cvatTemplateName = "CVAT"

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -1,0 +1,165 @@
+package migration
+
+import (
+	"database/sql"
+	v1 "github.com/onepanelio/core/pkg"
+	"github.com/pressly/goose"
+	"log"
+)
+
+const cvatWorkspaceTemplate = `# Docker containers that are part of the Workspace
+containers:
+- name: cvat-db
+  image: postgres:10-alpine
+  env:
+  - name: POSTGRES_USER
+    value: root
+  - name: POSTGRES_DB
+    value: cvat
+  - name: POSTGRES_HOST_AUTH_METHOD
+    value: trust
+  - name: PGDATA
+    value: /var/lib/psql/data
+  ports:
+  - containerPort: 5432
+    name: tcp
+  volumeMounts:
+  - name: db
+    mountPath: /var/lib/psql
+- name: cvat-redis
+  image: redis:4.0-alpine
+  ports:
+  - containerPort: 6379
+    name: tcp
+- name: cvat
+  image: onepanel/cvat:v0.6.23
+  command: ["/bin/bash", "-c"]
+  args: ["/usr/bin/supervisord && /usr/bin/python3 ~/manage.py shell --command='import os;from django.contrib.auth.models import User;u = User(username=os.getenv('DJANGO_SUPERUSER_USERNAME','admin'));u.set_password(os.getenv('DJANGO_SUPERUSER_PASSWORD','admin'));u.is_superuser = True;u.is_staff = True;u.save();'"]
+  env:
+  - name: DJANGO_MODWSGI_EXTRA_ARGS
+    value: ""
+  - name: ALLOWED_HOSTS
+    value: '*'
+  - name: CVAT_REDIS_HOST
+    value: localhost
+  - name: CVAT_POSTGRES_HOST
+    value: localhost
+  - name: CVAT_SHARE_URL
+    value: /home/django/data
+  ports:
+  - containerPort: 8080
+    name: http
+  volumeMounts:
+  - name: data
+    mountPath: /home/django/data
+  - name: keys
+    mountPath: /home/django/keys
+  - name: logs
+    mountPath: /home/django/logs
+  - name: models
+    mountPath: /home/django/models
+- name: cvat-ui
+  image: onepanel/cvat-ui:v0.6.23
+  ports:
+  - containerPort: 80
+    name: http
+ports:
+- name: cvat-ui
+  port: 80
+  protocol: TCP
+  targetPort: 80
+- name: cvat
+  port: 8080
+  protocol: TCP
+  targetPort: 8080
+routes:
+- match:
+  - uri:
+      regex: /api/.*|/git/.*|/tensorflow/.*|/auto_annotation/.*|/analytics/.*|/static/.*|/admin/.*|/documentation/.*|/dextr/.*|/reid/.*
+  - queryParams:
+      id:
+        regex: \d+.*
+  route:
+  - destination:
+      port:
+        number: 8080
+- match:
+  - uri:
+      prefix: /
+  route:
+  - destination:
+      port:
+        number: 80
+postExecutionWorkflow:
+  entrypoint: main
+  templates:
+  - name: main
+    dag:
+       tasks:
+       - name: slack-notify
+         template: slack-notify
+  -  name: slack-notify
+     container:
+       image: technosophos/slack-notify
+       args:
+       - SLACK_USERNAME=onepanel SLACK_TITLE="Your workspace is ready" SLACK_ICON=https://www.gravatar.com/avatar/5c4478592fe00878f62f0027be59c1bd SLACK_MESSAGE="Your workspace is now running" ./slack-notify
+       command:
+       - sh
+       - -c
+`
+
+const cvatTemplateName = "cvat"
+
+func init() {
+	goose.AddMigration(Up20200528140124, Down20200528140124)
+}
+
+func Up20200528140124(tx *sql.Tx) error {
+	// This code is executed when the migration is applied.
+	//time.Sleep(2 * time.Second)
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	namespaces, err := client.ListOnepanelEnabledNamespaces()
+	if err != nil {
+		return err
+	}
+
+	workspaceTemplate := &v1.WorkspaceTemplate{
+		Name:     cvatTemplateName,
+		Manifest: cvatWorkspaceTemplate,
+	}
+
+	for _, namespace := range namespaces {
+		if _, err := client.CreateWorkspaceTemplate(namespace.Name, workspaceTemplate); err != nil {
+			log.Printf("error %v", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func Down20200528140124(tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+
+	client, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	namespaces, err := client.ListOnepanelEnabledNamespaces()
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaces {
+		if err := client.DeleteWorkspace(namespace.Name, cvatTemplateName); err != nil {
+			log.Printf("error %v", err.Error())
+		}
+	}
+
+	return nil
+}

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -3,6 +3,7 @@ package migration
 import (
 	"database/sql"
 	v1 "github.com/onepanelio/core/pkg"
+	uid2 "github.com/onepanelio/core/pkg/util/uid"
 	"github.com/pressly/goose"
 	"log"
 )
@@ -154,8 +155,12 @@ func Down20200528140124(tx *sql.Tx) error {
 		return err
 	}
 
+	uid, err := uid2.GenerateUID(cvatTemplateName, 30)
+	if err != nil {
+		return err
+	}
 	for _, namespace := range namespaces {
-		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, cvatTemplateName); err != nil {
+		if _, err := client.ArchiveWorkspaceTemplate(namespace.Name, uid); err != nil {
 			log.Printf("error %v", err.Error())
 		}
 	}

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -266,7 +266,7 @@ func (c *Client) UpdateWorkspaceStatus(namespace, uid string, status *WorkspaceS
 	return
 }
 
-func (c *Client) ListWorkspacesByTemplateId(namespace string, templateId uint64) (workspaces []*Workspace, err error) {
+func (c *Client) ListWorkspacesByTemplateID(namespace string, templateId uint64) (workspaces []*Workspace, err error) {
 	sb := sb.Select(getWorkspaceColumns("w", "")...).
 		From("workspaces w").
 		Where(sq.And{

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -328,7 +328,9 @@ func (c *Client) updateWorkspace(namespace, uid, workspaceAction, resourceAction
 	if err != nil {
 		return util.NewUserError(codes.NotFound, "Workspace not found.")
 	}
-
+	if workspace == nil {
+		return nil
+	}
 	config, err := c.GetSystemConfig()
 	if err != nil {
 		return

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -266,6 +266,8 @@ func (c *Client) UpdateWorkspaceStatus(namespace, uid string, status *WorkspaceS
 	return
 }
 
+// ListWorkspacesByTemplateID will return all the workspaces for a given workspace template id.
+// Sourced from database.
 func (c *Client) ListWorkspacesByTemplateID(namespace string, templateId uint64) (workspaces []*Workspace, err error) {
 	sb := sb.Select(getWorkspaceColumns("w", "")...).
 		From("workspaces w").
@@ -442,6 +444,8 @@ func (c *Client) DeleteWorkspace(namespace, uid string) (err error) {
 	return c.updateWorkspace(namespace, uid, "delete", "delete", &WorkspaceStatus{Phase: WorkspaceTerminating})
 }
 
+// ArchiveWorkspace archives by setting the workspace to delete or terminate.
+// Kicks off DB archiving and k8s cleaning.
 func (c *Client) ArchiveWorkspace(namespace, uid string) (err error) {
 	return c.updateWorkspace(namespace, uid, "delete", "delete", &WorkspaceStatus{Phase: WorkspaceTerminating})
 }

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -268,13 +268,13 @@ func (c *Client) UpdateWorkspaceStatus(namespace, uid string, status *WorkspaceS
 
 // ListWorkspacesByTemplateID will return all the workspaces for a given workspace template id.
 // Sourced from database.
-func (c *Client) ListWorkspacesByTemplateID(namespace string, templateId uint64) (workspaces []*Workspace, err error) {
+func (c *Client) ListWorkspacesByTemplateID(namespace string, templateID uint64) (workspaces []*Workspace, err error) {
 	sb := sb.Select(getWorkspaceColumns("w", "")...).
 		From("workspaces w").
 		Where(sq.And{
 			sq.Eq{
 				"w.namespace":             namespace,
-				"w.workspace_template_id": templateId,
+				"w.workspace_template_id": templateID,
 			},
 			sq.NotEq{
 				"phase": WorkspaceTerminated,

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -407,3 +407,7 @@ func (c *Client) ResumeWorkspace(namespace, uid string) (err error) {
 func (c *Client) DeleteWorkspace(namespace, uid string) (err error) {
 	return c.updateWorkspace(namespace, uid, "delete", "delete", &WorkspaceStatus{Phase: WorkspaceTerminating})
 }
+
+func (c *Client) ArchiveWorkspace(namespace, uid string) (err error) {
+	return c.updateWorkspace(namespace, uid, "delete", "delete", &WorkspaceStatus{Phase: WorkspaceTerminating})
+}

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -905,6 +905,16 @@ func (c *Client) ArchiveWorkspaceTemplate(namespace string, uid string) (archive
 		return false, nil
 	}
 
+	err = c.ArchiveWorkspace(namespace, uid)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"Namespace": namespace,
+			"UID":       uid,
+			"Error":     err.Error(),
+		}).Error("Archive Workspace Template k8s failed.")
+		return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
+	}
+
 	archived, err = c.ArchiveWorkflowTemplate(namespace, workspaceTemplate.UID)
 	if err != nil {
 		return false, err

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -468,8 +468,13 @@ func (c *Client) createWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 		RunWith(tx).
 		QueryRow().Scan(&workspaceTemplate.ID, &workspaceTemplate.CreatedAt)
 	if err != nil {
-		_, err := c.ArchiveWorkflowTemplate(namespace, workspaceTemplate.WorkflowTemplate.UID)
-		return nil, util.NewUserErrorWrap(err, "Workspace template")
+		_, errCleanUp := c.ArchiveWorkflowTemplate(namespace, workspaceTemplate.WorkflowTemplate.UID)
+		errorMsg := "Error with insert into workspace_templates. "
+		if errCleanUp != nil {
+			errorMsg += "Error with clean-up: ArchiveWorkflowTemplate. "
+			errorMsg += errCleanUp.Error()
+		}
+		return nil, util.NewUserErrorWrap(err, errorMsg) //return the source error
 	}
 
 	workspaceTemplateVersionID := uint64(0)
@@ -486,8 +491,13 @@ func (c *Client) createWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 		QueryRow().
 		Scan(&workspaceTemplateVersionID)
 	if err != nil {
-		_, err := c.ArchiveWorkflowTemplate(namespace, workspaceTemplate.WorkflowTemplate.UID)
-		return nil, err
+		_, errCleanUp := c.ArchiveWorkflowTemplate(namespace, workspaceTemplate.WorkflowTemplate.UID)
+		errorMsg := "Error with insert into workspace_templates_versions. "
+		if errCleanUp != nil {
+			errorMsg += "Error with clean-up: ArchiveWorkflowTemplate. "
+			errorMsg += errCleanUp.Error()
+		}
+		return nil, util.NewUserErrorWrap(err, errorMsg) //return the source error
 	}
 
 	if len(workspaceTemplate.Labels) != 0 {

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -480,7 +480,6 @@ func (c *Client) createWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 	workspaceTemplateVersionID := uint64(0)
 	err = sb.Insert("workspace_template_versions").
 		SetMap(sq.Eq{
-			"uid":                   uid,
 			"version":               workspaceTemplate.Version,
 			"is_latest":             workspaceTemplate.IsLatest,
 			"manifest":              workspaceTemplate.Manifest,

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -475,6 +475,7 @@ func (c *Client) createWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 	workspaceTemplateVersionID := uint64(0)
 	err = sb.Insert("workspace_template_versions").
 		SetMap(sq.Eq{
+			"uid":                   uid,
 			"version":               workspaceTemplate.Version,
 			"is_latest":             workspaceTemplate.IsLatest,
 			"manifest":              workspaceTemplate.Manifest,

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -879,15 +879,13 @@ func (c *Client) WorkspaceTemplateHasRunningWorkspaces(namespace string, uid str
 }
 
 // ArchiveWorkspaceTemplate archives and deletes resources associated with the workspace template.
-// If there is an already archived workspace template, it is left intact, only the un-archived one is considered.
-//
-// If there is no workspace template identified by the parameters, an error is returned with code NotFound.
-//
-// No checks are otherwise made to see if this action is valid.
 //
 // In particular, this action
 //
-// * Marks Workspace Template database record as archived.
+// * Code retrieves all un-archived workspace template versions.
+//
+// * Iterates through each version, grabbing all related workspaces.
+//		- Each workspace is archived (k8s cleaned-up, database entry marked archived)
 //
 // * Marks associated Workflow template as archived
 //
@@ -895,40 +893,57 @@ func (c *Client) WorkspaceTemplateHasRunningWorkspaces(namespace string, uid str
 //
 // * Deletes Workflow Executions in k8s
 func (c *Client) ArchiveWorkspaceTemplate(namespace string, uid string) (archived bool, err error) {
-	err = c.ArchiveWorkspace(namespace, uid)
+	wsTemps, err := c.ListWorkspaceTemplateVersions(namespace, uid)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"Namespace": namespace,
 			"UID":       uid,
 			"Error":     err.Error(),
-		}).Error("Archive Workspace Template k8s failed.")
+		}).Error("ListWorkspaceTemplateVersions failed.")
 		return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
 	}
+	for _, wsTemp := range wsTemps {
+		wsList, err := c.ListWorkspacesByTemplateId(namespace, wsTemp.WorkspaceTemplateVersionID)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"Namespace": namespace,
+				"UID":       uid,
+				"Error":     err.Error(),
+			}).Error("ListWorkspacesByTemplateId failed.")
+			return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
+		}
 
-	archived, err = c.archiveWorkspaceTemplateDB(namespace, uid)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"Namespace": namespace,
-			"UID":       uid,
-			"Error":     err.Error(),
-		}).Error("Archive Workspace Template failed.")
-		return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
-	}
+		for _, ws := range wsList {
+			err = c.ArchiveWorkspace(namespace, ws.UID)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"Namespace": namespace,
+					"UID":       uid,
+					"Error":     err.Error(),
+				}).Error("ArchiveWorkspace failed.")
+				return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
+			}
+		}
 
-	workspaceTemplate, err := c.GetWorkspaceTemplate(namespace, uid, 0)
-	if err != nil {
-		if err != sql.ErrNoRows {
-			return false, util.NewUserError(codes.Unknown, "Unable to get workspace template.")
+		_, err = c.archiveWorkspaceTemplateDB(namespace, wsTemp.UID)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"Namespace": namespace,
+				"UID":       uid,
+				"Error":     err.Error(),
+			}).Error("Archive Workspace Template DB Failed.")
+			return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
+		}
+
+		_, err = c.ArchiveWorkflowTemplate(namespace, wsTemp.UID)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"Namespace": namespace,
+				"UID":       uid,
+				"Error":     err.Error(),
+			}).Error("Archive Workflow Template Failed.")
+			return false, util.NewUserError(codes.Unknown, "Unable to archive workspace template.")
 		}
 	}
-	if workspaceTemplate == nil {
-		return false, util.NewUserError(codes.NotFound, "Workspace template not found.")
-	}
-
-	archived, err = c.ArchiveWorkflowTemplate(namespace, uid)
-	if err != nil {
-		return false, err
-	}
-
 	return true, nil
 }


### PR DESCRIPTION
What type of PR is this?

/kind enhancement

What this PR does:
This PR adds CVAT as a workspace template to the template builder.
- DB entries and k8s operations are carried out.
This also includes fixes to the JupyterLab migraiton

Which issue(s) this PR fixes:

closes onepanelio/core#317

Special notes for your reviewer:
Make sure you carry out the steps here first:
- https://github.com/onepanelio/manifests/pull/61

### If you want to test on your cluster directly
- Pull down this branch
- Run `make docker` to push the image to docker
- Update your cluster deployment for onepanel-core to use the commit-hash image
- Wait for changes to take affect
- Exec into your onepanel-core pod
- Run `./goose status` to verify that cvat migration is executed
Note: If you're seeing crash loops, check the onepanel-core logs. The jupyter and cvat migrations throw a fatal log if an error is encountered while executing.

#### Assuming the initial migration up ran without errors:
- Check CVAT is available as a template in workspaces
- Create 1-2 workspaces with CVAT as base
- Wait for them to start up or to appear in the UI (database, k8s entries)
- Run `goose down` inside the pod.
- You should see no errors
- The workspaces should now be flagged as "terminating" in the UI
- Database entries for workspace_templates will show archived, along with the related workflow_template


### If you are developing locally, off of code
- You need to make sure your kubeconfig context is pointing to a k8s cluster.
- Pull down core-ui; run `npm install`, `ng serve`
- Wait for web to start
- Pull down this branch for core
- Compile main.go, have it running so it's taking requests

#### Assuming the initial migration up ran without errors:
- Check CVAT is available as a template in workspaces
- Create 1-2 workspaces with CVAT as base
- Wait for them to start up or to appear in the UI (database, k8s entries)
- Compile `cmd/goose.go`, run `./goose down`
- You should see no errors
- The workspaces should now be flagged as "terminating" in the UI
- Database entries for workspace_templates will show archived, along with the related workflow_template
- Test again by running `./goose up`, creating more cvat, then `./goose down`