### PR TITLE
feat: workflow template created at is selected when listing workflow executions

### DIFF
--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -1527,7 +1527,7 @@ func workflowExecutionsSelectBuilderNoColumns(namespace, workflowTemplateUID, wo
 func workflowExecutionsSelectBuilder(namespace, workflowTemplateUID, workflowTemplateVersion string) sq.SelectBuilder {
 	sb := workflowExecutionsSelectBuilderNoColumns(namespace, workflowTemplateUID, workflowTemplateVersion)
 	sb = sb.Columns(getWorkflowExecutionColumns("we", "")...).
-		Columns(`wtv.version "workflow_template.version"`)
+		Columns(`wtv.version "workflow_template.version"`, `wtv.created_at "workflow_template.created_at"`)
 
 	return sb
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does**:

Selects the workflow template version createdAt timestamp when listing Workflow Executions.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#147

**Special notes for your reviewer**:

This fix complements the #147 core-ui fix.