### PR TITLE
feat: Allow users to define their own VolumeClaimTemplates

### DIFF
--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -80,11 +80,19 @@ func generateArguments(spec *WorkspaceSpec, config map[string]string) (err error
 		Required:    true,
 	})
 
+	// Map all the volumeClaimTemplates that have storage set
+	volumeStorageQuantityIsSet := make(map[string]bool)
+	for _, v := range spec.VolumeClaimTemplates {
+		if v.Spec.Resources.Requests != nil {
+			volumeStorageQuantityIsSet[v.ObjectMeta.Name] = true
+		}
+	}
 	// Volume size parameters
 	volumeClaimsMapped := make(map[string]bool)
 	for _, c := range spec.Containers {
 		for _, v := range c.VolumeMounts {
-			if volumeClaimsMapped[v.Name] {
+			// Skip if already mapped or storage size is set
+			if volumeClaimsMapped[v.Name] || volumeStorageQuantityIsSet[v.Name] {
 				continue
 			}
 

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -167,7 +167,7 @@ func createStatefulSetManifest(spec *WorkspaceSpec, config map[string]string) (s
 	var volumeClaims []map[string]interface{}
 	volumeClaimsMapped := make(map[string]bool)
 	// Add volumeClaims that the user has added first
-	for _, v := range spec.VolumeClaims {
+	for _, v := range spec.VolumeClaimTemplates {
 		if volumeClaimsMapped[v.ObjectMeta.Name] {
 			continue
 		}

--- a/pkg/workspace_types.go
+++ b/pkg/workspace_types.go
@@ -47,11 +47,12 @@ type Workspace struct {
 }
 
 type WorkspaceSpec struct {
-	Arguments             *Arguments                 `json:"arguments" protobuf:"bytes,1,opt,name=arguments"`
-	Containers            []corev1.Container         `json:"containers" protobuf:"bytes,3,opt,name=containers"`
-	Ports                 []corev1.ServicePort       `json:"ports" protobuf:"bytes,4,opt,name=ports"`
-	Routes                []*networking.HTTPRoute    `json:"routes" protobuf:"bytes,5,opt,name=routes"`
-	PostExecutionWorkflow *wfv1.WorkflowTemplateSpec `json:"postExecutionWorkflow" protobuf:"bytes,6,opt,name=postExecutionWorkflow"`
+	Arguments             *Arguments                     `json:"arguments" protobuf:"bytes,1,opt,name=arguments"`
+	Containers            []corev1.Container             `json:"containers" protobuf:"bytes,3,opt,name=containers"`
+	Ports                 []corev1.ServicePort           `json:"ports" protobuf:"bytes,4,opt,name=ports"`
+	Routes                []*networking.HTTPRoute        `json:"routes" protobuf:"bytes,5,opt,name=routes"`
+	VolumeClaims          []corev1.PersistentVolumeClaim `json:"volumeClaims" protobuf:"bytes,6,opt,name=volumeClaims"`
+	PostExecutionWorkflow *wfv1.WorkflowTemplateSpec     `json:"postExecutionWorkflow" protobuf:"bytes,7,opt,name=postExecutionWorkflow"`
 }
 
 // returns all of the columns for workspace modified by alias, destination.

--- a/pkg/workspace_types.go
+++ b/pkg/workspace_types.go
@@ -51,7 +51,7 @@ type WorkspaceSpec struct {
 	Containers            []corev1.Container             `json:"containers" protobuf:"bytes,3,opt,name=containers"`
 	Ports                 []corev1.ServicePort           `json:"ports" protobuf:"bytes,4,opt,name=ports"`
 	Routes                []*networking.HTTPRoute        `json:"routes" protobuf:"bytes,5,opt,name=routes"`
-	VolumeClaims          []corev1.PersistentVolumeClaim `json:"volumeClaims" protobuf:"bytes,6,opt,name=volumeClaims"`
+	VolumeClaimTemplates  []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates" protobuf:"bytes,6,opt,name=volumeClaimTemplates"`
 	PostExecutionWorkflow *wfv1.WorkflowTemplateSpec     `json:"postExecutionWorkflow" protobuf:"bytes,7,opt,name=postExecutionWorkflow"`
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Allow users to define their own VolumeClaimTemplates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#279

**Special notes for your reviewer**:
These can be set in Workspace templates as follows:
```
volumeClaimTemplates:
- metadata:
    name: data
  spec:
    accessModes: [ "ReadWriteOnce" ]
    storageClass: "my-storage-class"
    resources:
      requests:
        storage: 1Gi
```

If `storageClass` is not set, it defaults to `onepanel`.

If `resource.requests.storage` is set, then no `sys-<name>-volume-size` parameter is generated for the Workspace.

