### PR TITLE
feat: runtime variables and system config change reload

### DIFF
--- a/db/20200617122509_remove_url_from_workspaces.sql
+++ b/db/20200617122509_remove_url_from_workspaces.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE workspaces DROP COLUMN url;
+
+-- +goose Down
+ALTER TABLE workspaces ADD COLUMN url TEXT;
+UPDATE workspaces set url = '';
+ALTER TABLE workspaces ALTER COLUMN url SET NOT NULL;

--- a/go.sum
+++ b/go.sum
@@ -730,6 +730,7 @@ k8s.io/apimachinery v0.0.0-20191219145857-f69eda767ee8/go.mod h1:mhhO3hoLkWO+2eC
 k8s.io/apimachinery v0.16.4/go.mod h1:llRdnznGEAqC3DcNm6yEj472xaFVfLM7hnYofMb12tQ=
 k8s.io/apimachinery v0.16.7-beta.0 h1:1cNiN7ZXJzlWq7dnWojG5UcrX1AIfQqpbyuzhu7Bhsc=
 k8s.io/apimachinery v0.16.7-beta.0/go.mod h1:mhhO3hoLkWO+2eCvqjPtH2Ly92l9nJDwsswzWKpkN2w=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/client-go v0.0.0-20191225075139-73fd2ddc9180/go.mod h1:ksVkYlACXo9hR9AV+cYyCkuWL1xnWcGtAFxsfqMcozg=
 k8s.io/client-go v0.16.4 h1:sf+FEZXYhJNjpTZapQDLvvN+0kBeUTxCYxlXcVdhv2E=
 k8s.io/client-go v0.16.4/go.mod h1:ZgxhFDxSnoKY0J0U2/Y1C8obKDdlhGPZwA7oHH863Ok=

--- a/main.go
+++ b/main.go
@@ -5,6 +5,12 @@ import (
 	"flag"
 	"fmt"
 	_ "github.com/onepanelio/core/db"
+	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	k8runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/tools/cache"
 	"net"
 	"net/http"
 
@@ -37,29 +43,44 @@ var (
 func main() {
 	flag.Parse()
 
-	kubeConfig := v1.NewConfig()
-	client, err := v1.NewClient(kubeConfig, nil, nil)
-	if err != nil {
-		log.Fatalf("Failed to connect to Kubernetes cluster: %v", err)
-	}
-	sysConfig, err := client.GetSystemConfig()
-	if err != nil {
-		log.Fatalf("Failed to get system config: %v", err)
-	}
+	// stopCh is used to indicate when the RPC server should reload.
+	// We do this when the configuration has been changed, so the server has the latest configuration
+	stopCh := make(chan struct{})
 
-	databaseDataSourceName := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=disable",
-		sysConfig["databaseHost"], sysConfig["databaseUsername"], sysConfig["databasePassword"], sysConfig["databaseName"])
+	go func() {
+		for {
+			kubeConfig := v1.NewConfig()
+			client, err := v1.NewClient(kubeConfig, nil, nil)
+			if err != nil {
+				log.Fatalf("Failed to connect to Kubernetes cluster: %v", err)
+			}
 
-	db := sqlx.MustConnect(sysConfig["databaseDriverName"], databaseDataSourceName)
-	if err := goose.Run("up", db.DB, "db"); err != nil {
-		log.Fatalf("Failed to run database migrations: %v", err)
-	}
+			client.ClearSystemConfigCache()
+			sysConfig, err := client.GetSystemConfig()
+			if err != nil {
+				log.Fatalf("Failed to get system config: %v", err)
+			}
 
-	go startRPCServer(db, kubeConfig, sysConfig)
+			databaseDataSourceName := fmt.Sprintf("host=%v user=%v password=%v dbname=%v sslmode=disable",
+				sysConfig["databaseHost"], sysConfig["databaseUsername"], sysConfig["databasePassword"], sysConfig["databaseName"])
+
+			db := sqlx.MustConnect(sysConfig["databaseDriverName"], databaseDataSourceName)
+			if err := goose.Run("up", db.DB, "db"); err != nil {
+				log.Fatalf("Failed to run database migrations: %v", err)
+			}
+
+			s := startRPCServer(db, kubeConfig, sysConfig, stopCh)
+
+			<-stopCh
+
+			s.Stop()
+		}
+	}()
+
 	startHTTPProxy()
 }
 
-func startRPCServer(db *v1.DB, kubeConfig *v1.Config, sysConfig v1.SystemConfig) {
+func startRPCServer(db *v1.DB, kubeConfig *v1.Config, sysConfig v1.SystemConfig, stopCh chan struct{}) *grpc.Server {
 	log.Printf("Starting RPC server on port %v", *rpcPort)
 	lis, err := net.Listen("tcp", *rpcPort)
 	if err != nil {
@@ -103,9 +124,27 @@ func startRPCServer(db *v1.DB, kubeConfig *v1.Config, sysConfig v1.SystemConfig)
 	api.RegisterWorkspaceTemplateServiceServer(s, server.NewWorkspaceTemplateServer())
 	api.RegisterWorkspaceServiceServer(s, server.NewWorkspaceServer())
 
-	if err := s.Serve(lis); err != nil {
-		log.Fatalf("Failed to serve RPC server: %v", err)
+	client, err := v1.NewClient(kubeConfig, db, sysConfig)
+	if err != nil {
+		log.Fatalf("Unable to create client: %v", err)
 	}
+
+	go Run(client, "onepanel", stopCh, func(configMap *corev1.ConfigMap) error {
+		log.Printf("Configmap changed")
+		stopCh <- struct{}{}
+
+		return nil
+	})
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Failed to serve RPC server: %v", err)
+		}
+
+		log.Infof("GRPC finished")
+	}()
+
+	return s
 }
 
 func startHTTPProxy() {
@@ -158,4 +197,49 @@ func registerHandler(register registerFunc, ctx context.Context, mux *runtime.Se
 	if err != nil {
 		log.Fatalf("Failed to register handler: %v", err)
 	}
+}
+
+func Run(client *v1.Client, namespace string, stopCh <-chan struct{}, onChange func(*corev1.ConfigMap) error) {
+	restClient := client.CoreV1().RESTClient()
+	resource := "configmaps"
+	fieldSelector := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", "onepanel"))
+	listFunc := func(options apiv1.ListOptions) (k8runtime.Object, error) {
+		options.FieldSelector = fieldSelector.String()
+		req := restClient.Get().
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, apiv1.ParameterCodec)
+		return req.Do().Get()
+	}
+	watchFunc := func(options apiv1.ListOptions) (watch.Interface, error) {
+		options.Watch = true
+		options.FieldSelector = fieldSelector.String()
+		req := restClient.Get().
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, apiv1.ParameterCodec)
+		return req.Watch()
+	}
+	source := &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+	_, controller := cache.NewInformer(
+		source,
+		&corev1.ConfigMap{},
+		0,
+		cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(old, new interface{}) {
+				oldCM := old.(*corev1.ConfigMap)
+				newCM := new.(*corev1.ConfigMap)
+				if oldCM.ResourceVersion == newCM.ResourceVersion {
+					return
+				}
+				if newCm, ok := new.(*corev1.ConfigMap); ok {
+					log.Infof("Detected ConfigMap update.")
+					if err := onChange(newCm); err != nil {
+						log.Errorf("Error on calling onChange callback: %v", err)
+					}
+				}
+			},
+		})
+	controller.Run(stopCh)
+	log.Infof("Watching config map updates")
 }

--- a/pkg/config.go
+++ b/pkg/config.go
@@ -26,6 +26,12 @@ func (c *Client) getConfigMap(namespace, name string) (configMap *ConfigMap, err
 	return
 }
 
+// ClearSystemConfigCache wipes out the cached system configuration so that the next call to
+// GetSystemConfig will pull it from the resources
+func (c *Client) ClearSystemConfigCache() {
+	c.systemConfig = nil
+}
+
 // GetSystemConfig loads various system configurations and bundles them into a map.
 // The configuration is cached once it is loaded, and that cached value is used from here on out.
 func (c *Client) GetSystemConfig() (config map[string]string, err error) {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -328,6 +328,8 @@ func (c *Client) ValidateWorkflowExecution(namespace string, manifest []byte) (e
 	return
 }
 
+// CreateWorkflowExecution creates an argo workflow execution and related resources.
+// Note that the workflow template is loaded from the database/k8s, so workflow.WorkflowTemplate.Manifest is not used.
 func (c *Client) CreateWorkflowExecution(namespace string, workflow *WorkflowExecution, runtimeVars *RuntimeVars) (*WorkflowExecution, error) {
 	workflowTemplate, err := c.GetWorkflowTemplate(namespace, workflow.WorkflowTemplate.UID, workflow.WorkflowTemplate.Version)
 	if err != nil {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -6,11 +6,11 @@ import (
 	"errors"
 	"fmt"
 	sq "github.com/Masterminds/squirrel"
-	"github.com/ghodss/yaml"
 	"github.com/onepanelio/core/pkg/util/label"
 	"github.com/onepanelio/core/pkg/util/pagination"
 	"github.com/onepanelio/core/pkg/util/ptr"
 	uid2 "github.com/onepanelio/core/pkg/util/uid"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/watch"
@@ -328,7 +328,7 @@ func (c *Client) ValidateWorkflowExecution(namespace string, manifest []byte) (e
 	return
 }
 
-func (c *Client) CreateWorkflowExecution(namespace string, workflow *WorkflowExecution) (*WorkflowExecution, error) {
+func (c *Client) CreateWorkflowExecution(namespace string, workflow *WorkflowExecution, runtimeVars *RuntimeVars) (*WorkflowExecution, error) {
 	workflowTemplate, err := c.GetWorkflowTemplate(namespace, workflow.WorkflowTemplate.UID, workflow.WorkflowTemplate.Version)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -337,6 +337,31 @@ func (c *Client) CreateWorkflowExecution(namespace string, workflow *WorkflowExe
 			"Error":     err.Error(),
 		}).Error("Error with getting workflow template.")
 		return nil, util.NewUserError(codes.NotFound, "Error with getting workflow template.")
+	}
+
+	if runtimeVars != nil && workflowTemplate.ArgoWorkflowTemplate != nil {
+		argoTemplate := workflowTemplate.ArgoWorkflowTemplate
+		for _, param := range runtimeVars.AdditionalParameters {
+			argoTemplate.Spec.Arguments.Parameters = append(argoTemplate.Spec.Arguments.Parameters, wfv1.Parameter{
+				Name:  param.Name,
+				Value: param.Value,
+			})
+		}
+
+		finalTemplates := make([]wfv1.Template, 0)
+		for i := range argoTemplate.Spec.Templates {
+			template := &argoTemplate.Spec.Templates[i]
+
+			if template.Name == "stateful-set-resource" {
+				template.Resource.Manifest = runtimeVars.StatefulSetManifest
+			}
+
+			if template.Name != runtimeVars.VirtualService.Name {
+				finalTemplates = append(finalTemplates, *template)
+			}
+		}
+		finalTemplates = append(finalTemplates, *runtimeVars.VirtualService)
+		workflowTemplate.ArgoWorkflowTemplate.Spec.Templates = finalTemplates
 	}
 
 	// TODO: Need to pull system parameters from k8s config/secret here, example: HOST
@@ -416,7 +441,7 @@ func (c *Client) CloneWorkflowExecution(namespace, uid string) (*WorkflowExecuti
 		return nil, err
 	}
 
-	return c.CreateWorkflowExecution(namespace, workflowExecution)
+	return c.CreateWorkflowExecution(namespace, workflowExecution, nil)
 }
 
 func (c *Client) insertPreWorkflowExecutionStatistic(namespace, name string, workflowTemplateVersionId uint64, createdAt time.Time, uid string, parameters []Parameter) (newId uint64, err error) {

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -154,7 +154,6 @@ func (c *Client) CreateWorkspace(namespace string, workspace *Workspace) (*Works
 	if sysHost == nil {
 		return nil, fmt.Errorf("sys-host parameter not found")
 	}
-	workspace.URL = *sysHost
 
 	existingWorkspace, err := c.GetWorkspace(namespace, workspace.UID)
 	if err != nil {

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -116,7 +116,6 @@ func (c *Client) createWorkspace(namespace string, parameters []byte, workspace 
 			"started_at":                 time.Now().UTC(),
 			"workspace_template_id":      workspace.WorkspaceTemplate.ID,
 			"workspace_template_version": workspace.WorkspaceTemplate.Version,
-			"url":                        workspace.URL,
 		}).
 		Suffix("RETURNING id, created_at").
 		RunWith(c.DB).

--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -98,10 +98,21 @@ func injectWorkspaceSystemParameters(namespace string, workspace *Workspace, wor
 }
 
 func (c *Client) createWorkspace(namespace string, parameters []byte, workspace *Workspace) (*Workspace, error) {
-	_, err := c.CreateWorkflowExecution(namespace, &WorkflowExecution{
+	systemConfig, err := c.GetSystemConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeVars, err := workspace.WorkspaceTemplate.RuntimeVars(systemConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = c.CreateWorkflowExecution(namespace, &WorkflowExecution{
 		Parameters:       workspace.Parameters,
 		WorkflowTemplate: workspace.WorkspaceTemplate.WorkflowTemplate,
-	})
+	}, runtimeVars)
+
 	if err != nil {
 		return nil, err
 	}
@@ -392,7 +403,7 @@ func (c *Client) updateWorkspace(namespace, uid, workspaceAction, resourceAction
 	_, err = c.CreateWorkflowExecution(namespace, &WorkflowExecution{
 		Parameters:       workspace.Parameters,
 		WorkflowTemplate: workspace.WorkspaceTemplate.WorkflowTemplate,
-	})
+	}, nil)
 	if err != nil {
 		return
 	}

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -27,7 +27,7 @@ func parseWorkspaceSpec(template string) (spec *WorkspaceSpec, err error) {
 	return
 }
 
-func generateArguments(spec *WorkspaceSpec, config map[string]string) (err error) {
+func generateArguments(spec *WorkspaceSpec, config map[string]string, withRuntimeVars bool) (err error) {
 	systemParameters := make([]Parameter, 0)
 	// Resource action parameter
 	systemParameters = append(systemParameters, Parameter{
@@ -52,12 +52,7 @@ func generateArguments(spec *WorkspaceSpec, config map[string]string) (err error
 		Value: ptr.String("create"),
 		Type:  "input.hidden",
 	})
-	// Host
-	systemParameters = append(systemParameters, Parameter{
-		Name:  "sys-host",
-		Value: ptr.String(config["ONEPANEL_DOMAIN"]),
-		Type:  "input.hidden",
-	})
+
 	// UID placeholder
 	systemParameters = append(systemParameters, Parameter{
 		Name:  "sys-uid",
@@ -65,20 +60,29 @@ func generateArguments(spec *WorkspaceSpec, config map[string]string) (err error
 		Type:  "input.hidden",
 	})
 
-	// Node pool parameter and options
-	var options []*ParameterOption
-	if err = yaml.Unmarshal([]byte(config["applicationNodePoolOptions"]), &options); err != nil {
-		return
+	if withRuntimeVars {
+		// Host
+		systemParameters = append(systemParameters, Parameter{
+			Name:  "sys-host",
+			Value: ptr.String(config["ONEPANEL_DOMAIN"]),
+			Type:  "input.hidden",
+		})
+
+		// Node pool parameter and options
+		var options []*ParameterOption
+		if err = yaml.Unmarshal([]byte(config["applicationNodePoolOptions"]), &options); err != nil {
+			return
+		}
+		systemParameters = append(systemParameters, Parameter{
+			Name:        "sys-node-pool",
+			Value:       ptr.String(options[0].Value),
+			Type:        "select.select",
+			Options:     options,
+			DisplayName: ptr.String("Node pool"),
+			Hint:        ptr.String("Name of node pool or group"),
+			Required:    true,
+		})
 	}
-	systemParameters = append(systemParameters, Parameter{
-		Name:        "sys-node-pool",
-		Value:       ptr.String(options[0].Value),
-		Type:        "select.select",
-		Options:     options,
-		DisplayName: ptr.String("Node pool"),
-		Hint:        ptr.String("Name of node pool or group"),
-		Required:    true,
-	})
 
 	// Map all the volumeClaimTemplates that have storage set
 	volumeStorageQuantityIsSet := make(map[string]bool)
@@ -144,7 +148,7 @@ func createServiceManifest(spec *WorkspaceSpec) (serviceManifest string, err err
 	return
 }
 
-func createVirtualServiceManifest(spec *WorkspaceSpec) (virtualServiceManifest string, err error) {
+func createVirtualServiceManifest(spec *WorkspaceSpec, withRuntimeVars bool) (virtualServiceManifest string, err error) {
 	for _, h := range spec.Routes {
 		for _, r := range h.Route {
 			r.Destination.Host = "{{workflow.parameters.sys-uid}}"
@@ -156,12 +160,16 @@ func createVirtualServiceManifest(spec *WorkspaceSpec) (virtualServiceManifest s
 		"metadata": metav1.ObjectMeta{
 			Name: "{{workflow.parameters.sys-uid}}",
 		},
-		"spec": networking.VirtualService{
+	}
+
+	if withRuntimeVars {
+		virtualService["spec"] = networking.VirtualService{
 			Http:     spec.Routes,
 			Gateways: []string{"istio-system/ingressgateway"},
 			Hosts:    []string{"{{workflow.parameters.sys-host}}"},
-		},
+		}
 	}
+
 	virtualServiceManifestBytes, err := yaml.Marshal(virtualService)
 	if err != nil {
 		return
@@ -171,7 +179,7 @@ func createVirtualServiceManifest(spec *WorkspaceSpec) (virtualServiceManifest s
 	return
 }
 
-func createStatefulSetManifest(spec *WorkspaceSpec, config map[string]string) (statefulSetManifest string, err error) {
+func createStatefulSetManifest(spec *WorkspaceSpec, config map[string]string, withRuntimeVars bool) (statefulSetManifest string, err error) {
 	var volumeClaims []map[string]interface{}
 	volumeClaimsMapped := make(map[string]bool)
 	// Add volumeClaims that the user has added first
@@ -248,6 +256,33 @@ func createStatefulSetManifest(spec *WorkspaceSpec, config map[string]string) (s
 		})
 	}
 
+	template := corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"app": "{{workflow.parameters.sys-uid}}",
+			},
+		},
+	}
+
+	if withRuntimeVars {
+		template.Spec = corev1.PodSpec{
+			NodeSelector: map[string]string{
+				config["applicationNodePoolLabel"]: "{{workflow.parameters.sys-node-pool}}",
+			},
+			Containers: spec.Containers,
+			Volumes: []corev1.Volume{
+				{
+					Name: "sys-dshm",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{
+							Medium: corev1.StorageMediumMemory,
+						},
+					},
+				},
+			},
+		}
+	}
+
 	statefulSet := map[string]interface{}{
 		"apiVersion": "apps/v1",
 		"kind":       "StatefulSet",
@@ -262,29 +297,7 @@ func createStatefulSetManifest(spec *WorkspaceSpec, config map[string]string) (s
 					"app": "{{workflow.parameters.sys-uid}}",
 				},
 			},
-			"template": corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"app": "{{workflow.parameters.sys-uid}}",
-					},
-				},
-				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						config["applicationNodePoolLabel"]: "{{workflow.parameters.sys-node-pool}}",
-					},
-					Containers: spec.Containers,
-					Volumes: []corev1.Volume{
-						{
-							Name: "sys-dshm",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{
-									Medium: corev1.StorageMediumMemory,
-								},
-							},
-						},
-					},
-				},
-			},
+			"template":             template,
 			"volumeClaimTemplates": volumeClaims,
 		},
 	}
@@ -656,7 +669,7 @@ func (c *Client) getWorkspaceTemplateByName(namespace, name string) (workspaceTe
 	return
 }
 
-func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *WorkspaceTemplate) (workflowTemplate *WorkflowTemplate, err error) {
+func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *WorkspaceTemplate, withRuntimeVars bool) (workflowTemplate *WorkflowTemplate, err error) {
 	if workspaceTemplate == nil || workspaceTemplate.Manifest == "" {
 		return nil, util.NewUserError(codes.InvalidArgument, "Workspace template manifest is required")
 	}
@@ -671,7 +684,7 @@ func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *Wo
 		return nil, err
 	}
 
-	if err = generateArguments(workspaceSpec, config); err != nil {
+	if err = generateArguments(workspaceSpec, config, withRuntimeVars); err != nil {
 		return nil, err
 	}
 
@@ -680,12 +693,12 @@ func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *Wo
 		return nil, err
 	}
 
-	virtualServiceManifest, err := createVirtualServiceManifest(workspaceSpec)
+	virtualServiceManifest, err := createVirtualServiceManifest(workspaceSpec, withRuntimeVars)
 	if err != nil {
 		return nil, err
 	}
 
-	containersManifest, err := createStatefulSetManifest(workspaceSpec, config)
+	containersManifest, err := createStatefulSetManifest(workspaceSpec, config, withRuntimeVars)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +718,7 @@ func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *Wo
 
 // CreateWorkspaceTemplateWorkflowTemplate generates and returns a workflowTemplate for a given workspaceTemplate manifest
 func (c *Client) GenerateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *WorkspaceTemplate) (workflowTemplate *WorkflowTemplate, err error) {
-	workflowTemplate, err = c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate)
+	workflowTemplate, err = c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate, true)
 	if err != nil {
 		return nil, err
 	}
@@ -732,7 +745,7 @@ func (c *Client) CreateWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 		return nil, util.NewUserError(codes.AlreadyExists, message)
 	}
 
-	workspaceTemplate.WorkflowTemplate, err = c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate)
+	workspaceTemplate.WorkflowTemplate, err = c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate, false)
 	if err != nil {
 		return nil, err
 	}
@@ -773,6 +786,15 @@ func (c *Client) GetWorkspaceTemplate(namespace, uid string, version int64) (wor
 		return
 	}
 
+	sysConfig, err := c.GetSystemConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := workspaceTemplate.InjectRuntimeVariables(sysConfig); err != nil {
+		return nil, err
+	}
+
 	return
 }
 
@@ -788,7 +810,7 @@ func (c *Client) UpdateWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 	workspaceTemplate.ID = existingWorkspaceTemplate.ID
 	workspaceTemplate.Name = existingWorkspaceTemplate.UID
 
-	updatedWorkflowTemplate, err := c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate)
+	updatedWorkflowTemplate, err := c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workspace_template_types.go
+++ b/pkg/workspace_template_types.go
@@ -1,6 +1,10 @@
 package v1
 
 import (
+	"fmt"
+	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
+	"github.com/onepanelio/core/pkg/util/ptr"
+	"gopkg.in/yaml.v2"
 	"time"
 )
 
@@ -19,6 +23,152 @@ type WorkspaceTemplate struct {
 	WorkflowTemplate           *WorkflowTemplate `db:"workflow_template"`
 	Labels                     map[string]string
 	WorkflowTemplateID         uint64 `db:"workflow_template_id"`
+}
+
+// InjectRuntimeVariables will inject all runtime variables into the WorkflowTemplate's manifest.
+func (wt *WorkspaceTemplate) InjectRuntimeVariables(config map[string]string) error {
+	if wt.WorkflowTemplate == nil {
+		return fmt.Errorf("workflow Template is nil for workspace template")
+	}
+
+	runtimeVars, err := wt.RuntimeVars(config)
+	if err != nil {
+		return err
+	}
+
+	parsedManifest := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(wt.WorkflowTemplate.Manifest), parsedManifest); err != nil {
+		return err
+	}
+
+	arguments, ok := parsedManifest["arguments"]
+	if !ok {
+		return fmt.Errorf("argumnets not found in workflow template manifest")
+	}
+
+	argumentsMap := arguments.(map[interface{}]interface{})
+	parameters := argumentsMap["parameters"]
+	parametersArray := parameters.([]interface{})
+
+	for _, param := range runtimeVars.AdditionalParameters {
+		parametersArray = append(parametersArray, param)
+	}
+
+	templates := parsedManifest["templates"].([]interface{})
+	finalTemplates := make([]interface{}, 0)
+	for _, t := range templates {
+		template := t.(map[interface{}]interface{})
+		name, ok := template["name"]
+		if !ok {
+			continue
+		}
+
+		if name == runtimeVars.VirtualService.Name {
+			continue
+		}
+
+		if name == "stateful-set-resource" {
+			resource := template["resource"]
+			resourceMap := resource.(map[interface{}]interface{})
+			resourceMap["manifest"] = runtimeVars.StatefulSetManifest
+		}
+	}
+	finalTemplates = append(finalTemplates, runtimeVars.VirtualService)
+	parsedManifest["templates"] = finalTemplates
+
+	resultManifest, err := yaml.Marshal(parsedManifest)
+	if err != nil {
+		return err
+	}
+
+	wt.WorkflowTemplate.Manifest = string(resultManifest)
+
+	return nil
+}
+
+// RuntimeVars contains data that is needed for workspaces to function at runtime.
+// This includes data that is configuration dependent, which may change.
+// For example, the sys-host might change because it depends on the ONEPANEL_DOMAIN config variable
+type RuntimeVars struct {
+	AdditionalParameters []*Parameter
+	VirtualService       *wfv1.Template
+	WorkspaceSpec        *WorkspaceSpec
+	StatefulSetManifest  string
+}
+
+// TODO document this and then maybe add separate functions to inject it
+func (wt *WorkspaceTemplate) RuntimeVars(config map[string]string) (runtimeVars *RuntimeVars, err error) {
+	if wt.WorkflowTemplate == nil {
+		err = fmt.Errorf("workflow Template is nil for workspace template")
+		return
+	}
+
+	runtimeVars = &RuntimeVars{}
+
+	workspaceSpec, err := parseWorkspaceSpec(wt.Manifest)
+	if err != nil {
+		return
+	}
+
+	runtimeVars.WorkspaceSpec = workspaceSpec
+	parsedManifest := make(map[string]interface{})
+	if err := yaml.Unmarshal([]byte(wt.WorkflowTemplate.Manifest), parsedManifest); err != nil {
+		return nil, err
+	}
+
+	arguments, ok := parsedManifest["arguments"]
+	if !ok {
+		err = fmt.Errorf("argumnets not found in workflow template manifest")
+		return
+	}
+
+	argumentsMap := arguments.(map[interface{}]interface{})
+	localParameters := argumentsMap["parameters"]
+	parametersArray := localParameters.([]interface{})
+
+	// sys-host
+	parametersArray = append(parametersArray, Parameter{
+		Name:  "sys-host",
+		Value: ptr.String(config["ONEPANEL_DOMAIN"]),
+		Type:  "input.hidden",
+	})
+
+	// Node pool parameter and options
+	var options []*ParameterOption
+	if err := yaml.Unmarshal([]byte(config["applicationNodePoolOptions"]), &options); err != nil {
+		return nil, err
+	}
+
+	runtimeVars.AdditionalParameters = append(runtimeVars.AdditionalParameters, &Parameter{
+		Name:        "sys-node-pool",
+		Value:       ptr.String(options[0].Value),
+		Type:        "select.select",
+		Options:     options,
+		DisplayName: ptr.String("Node pool"),
+		Hint:        ptr.String("Name of node pool or group"),
+		Required:    true,
+	})
+
+	vs, err := createVirtualServiceManifest(workspaceSpec, true)
+	if err != nil {
+		return nil, err
+	}
+
+	runtimeVars.VirtualService = &wfv1.Template{
+		Name: "virtual-service-resource",
+		Resource: &wfv1.ResourceTemplate{
+			Action:   "{{workflow.parameters.sys-resource-action}}",
+			Manifest: vs,
+		},
+	}
+
+	statefulSet, err := createStatefulSetManifest(workspaceSpec, config, true)
+	if err != nil {
+		return nil, err
+	}
+	runtimeVars.StatefulSetManifest = statefulSet
+
+	return
 }
 
 func WorkspaceTemplatesToVersionIds(resources []*WorkspaceTemplate) (ids []uint64) {

--- a/pkg/workspace_template_types.go
+++ b/pkg/workspace_template_types.go
@@ -112,7 +112,7 @@ func (wt *WorkspaceTemplate) RuntimeVars(config map[string]string) (runtimeVars 
 }
 
 // InjectRuntimeVariables will inject all runtime variables into the WorkflowTemplate's manifest.
-func (wt *WorkspaceTemplate) InjectRuntimeVariables(config map[string]string) error {
+func (wt *WorkspaceTemplate) InjectRuntimeVariables(config SystemConfig) error {
 	if wt.WorkflowTemplate == nil {
 		return fmt.Errorf("workflow Template is nil for workspace template")
 	}
@@ -139,6 +139,7 @@ func (wt *WorkspaceTemplate) InjectRuntimeVariables(config map[string]string) er
 	for _, param := range runtimeVars.AdditionalParameters {
 		parametersArray = append(parametersArray, param)
 	}
+	argumentsMap["parameters"] = parametersArray
 
 	templates := parsedManifest["templates"].([]interface{})
 	finalTemplates := make([]interface{}, 0)
@@ -158,6 +159,8 @@ func (wt *WorkspaceTemplate) InjectRuntimeVariables(config map[string]string) er
 			resourceMap := resource.(map[interface{}]interface{})
 			resourceMap["manifest"] = runtimeVars.StatefulSetManifest
 		}
+
+		finalTemplates = append(finalTemplates, template)
 	}
 	finalTemplates = append(finalTemplates, runtimeVars.VirtualService)
 	parsedManifest["templates"] = finalTemplates
@@ -187,7 +190,7 @@ func WorkspaceTemplatesToVersionIds(resources []*WorkspaceTemplate) (ids []uint6
 	return
 }
 
-// returns all of the columns for workspace template modified by alias, destination.
+// getWorkspaceTemplateColumns returns all of the columns for workspace template modified by alias, destination.
 // see formatColumnSelect
 func getWorkspaceTemplateColumns(alias string, destination string, extraColumns ...string) []string {
 	columns := []string{"id", "uid", "created_at", "modified_at", "name", "namespace", "is_archived", "workflow_template_id"}

--- a/pkg/workspace_types.go
+++ b/pkg/workspace_types.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"fmt"
 	wfv1 "github.com/argoproj/argo/pkg/apis/workflow/v1alpha1"
 	networking "istio.io/api/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
@@ -42,7 +43,6 @@ type Workspace struct {
 	WorkspaceTemplate        *WorkspaceTemplate       `db:"workspace_template" valid:"-"`
 	WorkspaceTemplateID      uint64                   `db:"workspace_template_id"`
 	WorkspaceTemplateVersion uint64                   `db:"workspace_template_version"`
-	URL                      string                   `db:"url"`                       // the path to the workspace, a url that you can access via http
 	WorkflowTemplateVersion  *WorkflowTemplateVersion `db:"workflow_template_version"` // helper to store data from workflow template version
 }
 
@@ -55,10 +55,17 @@ type WorkspaceSpec struct {
 	PostExecutionWorkflow *wfv1.WorkflowTemplateSpec     `json:"postExecutionWorkflow" protobuf:"bytes,7,opt,name=postExecutionWorkflow"`
 }
 
+// GetURL returns a url that can be used to access the workspace in a browser.
+// protocol is either http:// or https://
+// domain is the domain, e.g. test.onepanel.io
+func (w *Workspace) GetURL(protocol, domain string) string {
+	return fmt.Sprintf("%v%v--%v.%v", protocol, w.UID, w.Namespace, domain)
+}
+
 // returns all of the columns for workspace modified by alias, destination.
 // see formatColumnSelect
 func getWorkspaceColumns(alias string, destination string, extraColumns ...string) []string {
-	columns := []string{"id", "created_at", "modified_at", "uid", "name", "namespace", "parameters", "workspace_template_id", "workspace_template_version", "url"}
+	columns := []string{"id", "created_at", "modified_at", "uid", "name", "namespace", "parameters", "workspace_template_id", "workspace_template_version"}
 	return formatColumnSelect(columns, alias, destination, extraColumns...)
 }
 

--- a/server/workflow_server.go
+++ b/server/workflow_server.go
@@ -84,7 +84,7 @@ func (s *WorkflowServer) CreateWorkflowExecution(ctx context.Context, req *api.C
 		})
 	}
 
-	wf, err := client.CreateWorkflowExecution(req.Namespace, workflow)
+	wf, err := client.CreateWorkflowExecution(req.Namespace, workflow, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/server/workspace_server.go
+++ b/server/workspace_server.go
@@ -18,6 +18,7 @@ type WorkspaceServer struct{}
 func apiWorkspace(wt *v1.Workspace, config map[string]string) *api.Workspace {
 	protocol := "http://"
 	onepanelApiUrl := config["ONEPANEL_API_URL"]
+	domain := config["ONEPANEL_DOMAIN"]
 	if strings.HasPrefix(onepanelApiUrl, "https://") {
 		protocol = "https://"
 	}
@@ -26,7 +27,7 @@ func apiWorkspace(wt *v1.Workspace, config map[string]string) *api.Workspace {
 		Uid:       wt.UID,
 		Name:      wt.Name,
 		CreatedAt: wt.CreatedAt.UTC().Format(time.RFC3339),
-		Url:       protocol + wt.URL,
+		Url:       wt.GetURL(protocol, domain),
 	}
 	res.Parameters = converter.ParametersToAPI(wt.Parameters)
 

--- a/server/workspace_server.go
+++ b/server/workspace_server.go
@@ -9,25 +9,39 @@ import (
 	"github.com/onepanelio/core/pkg/util/ptr"
 	"github.com/onepanelio/core/server/auth"
 	"github.com/onepanelio/core/server/converter"
-	"strings"
+	log "github.com/sirupsen/logrus"
 	"time"
 )
 
 type WorkspaceServer struct{}
 
-func apiWorkspace(wt *v1.Workspace, config map[string]string) *api.Workspace {
-	protocol := "http://"
-	onepanelApiUrl := config["ONEPANEL_API_URL"]
-	domain := config["ONEPANEL_DOMAIN"]
-	if strings.HasPrefix(onepanelApiUrl, "https://") {
-		protocol = "https://"
+func apiWorkspace(wt *v1.Workspace, config v1.SystemConfig) *api.Workspace {
+	protocol := config.APIProtocol()
+	domain := config.Domain()
+
+	if protocol == nil {
+		log.WithFields(log.Fields{
+			"Method": "apiWorkspace",
+			"Error":  "protocol is nil",
+		})
+
+		return nil
+	}
+
+	if domain == nil {
+		log.WithFields(log.Fields{
+			"Method": "apiWorkspace",
+			"Error":  "domain is nil",
+		})
+
+		return nil
 	}
 
 	res := &api.Workspace{
 		Uid:       wt.UID,
 		Name:      wt.Name,
 		CreatedAt: wt.CreatedAt.UTC().Format(time.RFC3339),
-		Url:       wt.GetURL(protocol, domain),
+		Url:       wt.GetURL(*protocol, *domain),
 	}
 	res.Parameters = converter.ParametersToAPI(wt.Parameters)
 


### PR DESCRIPTION
**What this PR does**:

Updates the workspace templates so that runtime variables like the DOMAIN are injected when the workspace is is created instead of when the workspace template is created.

This also updates the server so that it reloads data upon a detected configuration change, so variables like DOMAIN are always up to date.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#348

**Special notes for your reviewer**:

For the runtime variables, there are 3 main places of interest.
- When we create a template for viewing, as when we generate a dynamic template while creating/editing a workspace template. In this situation, we need to inject runtime variables for things like the Machine Type dropdown.
- Whenever we get a Workspace Template, we need to modify the manifest to include the variables.
- When we create the Workflow Execution for a Workspace. The Argo WorkflowTemplate needs to have the appropriate variables injected into it.

NOTE:
If you attempt to view the YAML in the workflow execution, it will not have the injected variables as it gets the Workflow Execution, and we do not know to inject the runtime variables there. We might want to eventually add a method to get the workflow execution yaml for a Workspace to get around this.