### PR TITLE
fix: migrations crash 

### DIFF
--- a/db/20200421103946_add_back_workflow_template_versions.sql
+++ b/db/20200421103946_add_back_workflow_template_versions.sql
@@ -2,7 +2,7 @@
 CREATE TABLE workflow_template_versions
 (
     id                      serial PRIMARY KEY,
-    uid                     varchar(30) UNIQUE NOT NULL CHECK(uid <> ''),
+    uid                     varchar(30),
     workflow_template_id    integer NOT NULL REFERENCES workflow_templates ON DELETE CASCADE,
     version                 integer NOT NULL,
     is_latest               boolean NOT NULL,

--- a/db/20200525160514_add_jupyter_workspace_template.go
+++ b/db/20200525160514_add_jupyter_workspace_template.go
@@ -93,7 +93,7 @@ func Up20200525160514(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkspaceTemplate(namespace.Name, workspaceTemplate); err != nil {
-			log.Fatalf("error %v", err.Error())
+			return err
 		}
 	}
 

--- a/db/20200528140124_add_cvat_workspace_template.go
+++ b/db/20200528140124_add_cvat_workspace_template.go
@@ -137,7 +137,7 @@ func Up20200528140124(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkspaceTemplate(namespace.Name, workspaceTemplate); err != nil {
-			log.Fatalf("error %v", err.Error())
+			return err
 		}
 	}
 

--- a/db/20200605090509_add_pytorch_workflow_template.go
+++ b/db/20200605090509_add_pytorch_workflow_template.go
@@ -113,7 +113,7 @@ func Up20200605090509(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkflowTemplate(namespace.Name, workflowTemplate); err != nil {
-			log.Fatalf("error %v", err.Error())
+			return err
 		}
 	}
 

--- a/db/20200605090535_add_tensorflow_workflow_template.go
+++ b/db/20200605090535_add_tensorflow_workflow_template.go
@@ -113,7 +113,7 @@ func Up20200605090535(tx *sql.Tx) error {
 
 	for _, namespace := range namespaces {
 		if _, err := client.CreateWorkflowTemplate(namespace.Name, workflowTemplate); err != nil {
-			log.Fatalf("error %v", err.Error())
+			return err
 		}
 	}
 	return nil

--- a/db/20200616194847_remove_workflow_template_versions_uid.sql
+++ b/db/20200616194847_remove_workflow_template_versions_uid.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+ALTER TABLE workflow_template_versions DROP COLUMN uid;
+
+-- +goose Down
+ALTER TABLE workflow_template_versions ADD COLUMN uid VARCHAR(30);
+UPDATE workflow_template_versions SET uid = version::text;

--- a/pkg/labels.go
+++ b/pkg/labels.go
@@ -22,9 +22,6 @@ func (c *Client) ListLabels(resource string, uid string) (labels []*Label, err e
 	case TypeWorkflowTemplate:
 		sb = sb.Join("workflow_templates wt ON wt.id = l.resource_id").
 			Where(sq.Eq{"wt.uid": uid})
-	case TypeWorkflowTemplateVersion:
-		sb = sb.Join("workflow_template_versions wtv ON wtv.id = l.resource_id").
-			Where(sq.Eq{"wtv.uid": uid})
 	case TypeWorkflowExecution:
 		sb = sb.Join("workflow_executions we ON we.id = l.resource_id").
 			Where(sq.Eq{"we.uid": uid})

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -670,7 +670,7 @@ func getWorkflowTemplateColumns(alias string, destination string, extraColumns .
 // returns all of the columns for workflow template versions modified by alias, destination.
 // see formatColumnSelect
 func getWorkflowTemplateVersionColumns(alias string, destination string, extraColumns ...string) []string {
-	columns := []string{"id", "uid", "created_at", "version", "is_latest", "manifest"}
+	columns := []string{"id", "created_at", "version", "is_latest", "manifest"}
 	return formatColumnSelect(columns, alias, destination, extraColumns...)
 }
 

--- a/pkg/workflow_template.go
+++ b/pkg/workflow_template.go
@@ -374,7 +374,7 @@ func (c *Client) CreateWorkflowTemplate(namespace string, workflowTemplate *Work
 		return nil, util.NewUserError(codes.InvalidArgument, err.Error())
 	}
 
-	workflowTemplate, _, err := c.createWorkflowTemplate(namespace, workflowTemplate)
+	newWorkflowTemplate, _, err := c.createWorkflowTemplate(namespace, workflowTemplate)
 	if err != nil {
 		log.WithFields(log.Fields{
 			"Namespace":        namespace,
@@ -384,7 +384,7 @@ func (c *Client) CreateWorkflowTemplate(namespace string, workflowTemplate *Work
 		return nil, util.NewUserErrorWrap(err, "Workflow template")
 	}
 
-	return workflowTemplate, nil
+	return newWorkflowTemplate, nil
 }
 
 func (c *Client) CreateWorkflowTemplateVersion(namespace string, workflowTemplate *WorkflowTemplate) (*WorkflowTemplate, error) {


### PR DESCRIPTION
**What this PR does**:

Removes workflow_template_versions uid as it is not needed.

This also fixes an issue where migrations crash because the workflow_template_version.uid is set to a unix timestamp (which has second precision here). The migrations loop over many namespaces and the uid has a unique constraint. When it happens under a second, it crashes.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#355

**Special notes for your reviewer**:
