### PR TITLE
fix: get workspaces now returns up-to-date node pool options

### DIFF
--- a/db/go/20200525160514_add_jupyter_workspace_template.go
+++ b/db/go/20200525160514_add_jupyter_workspace_template.go
@@ -72,7 +72,10 @@ routes:
 const jupyterLabTemplateName = "JupyterLab"
 
 func initialize20200525160514() {
-	goose.AddMigration(Up20200525160514, Down20200525160514)
+	if _, ok := initializedMigrations[20200525160514]; !ok {
+		goose.AddMigration(Up20200525160514, Down20200525160514)
+		initializedMigrations[20200525160514] = true
+	}
 }
 
 func Up20200525160514(tx *sql.Tx) error {

--- a/db/go/20200528140124_add_cvat_workspace_template.go
+++ b/db/go/20200528140124_add_cvat_workspace_template.go
@@ -111,7 +111,10 @@ routes:
 const cvatTemplateName = "CVAT"
 
 func initialize20200528140124() {
-	goose.AddMigration(Up20200528140124, Down20200528140124)
+	if _, ok := initializedMigrations[20200528140124]; !ok {
+		goose.AddMigration(Up20200528140124, Down20200528140124)
+		initializedMigrations[20200528140124] = true
+	}
 }
 
 // Up20200528140124 will insert the cvatTemplate to each user.

--- a/db/go/20200605090509_add_pytorch_workflow_template.go
+++ b/db/go/20200605090509_add_pytorch_workflow_template.go
@@ -89,7 +89,10 @@ templates:
 const pytorchMnistWorkflowTemplateName = "PyTorch Training"
 
 func initialize20200605090509() {
-	goose.AddMigration(Up20200605090509, Down20200605090509)
+	if _, ok := initializedMigrations[20200605090509]; !ok {
+		goose.AddMigration(Up20200605090509, Down20200605090509)
+		initializedMigrations[20200605090509] = true
+	}
 }
 
 // Up20200605090509 will insert a Pytorch workflow template to each user.

--- a/db/go/20200605090535_add_tensorflow_workflow_template.go
+++ b/db/go/20200605090535_add_tensorflow_workflow_template.go
@@ -89,7 +89,10 @@ templates:
 const tensorflowWorkflowTemplateName = "TensorFlow Training"
 
 func initialize20200605090535() {
-	goose.AddMigration(Up20200605090535, Down20200605090535)
+	if _, ok := initializedMigrations[20200605090535]; !ok {
+		goose.AddMigration(Up20200605090535, Down20200605090535)
+		initializedMigrations[20200605090535] = true
+	}
 }
 
 // Up20200605090535 will insert a tensorflow workflow template to each user.

--- a/db/go/20200626113635_update_cvat_workspace_template.go
+++ b/db/go/20200626113635_update_cvat_workspace_template.go
@@ -119,7 +119,10 @@ routes:
 `
 
 func initialize20200626113635() {
-	goose.AddMigration(Up20200626113635, Down20200626113635)
+	if _, ok := initializedMigrations[20200626113635]; !ok {
+		goose.AddMigration(Up20200626113635, Down20200626113635)
+		initializedMigrations[20200626113635] = true
+	}
 }
 
 // Up20200626113635 updates the CVAT template to a new version.

--- a/db/go/20200704151301_update_cvat_workspace_template.go
+++ b/db/go/20200704151301_update_cvat_workspace_template.go
@@ -120,8 +120,11 @@ routes:
 #       - -c
 `
 
-func init() {
-	goose.AddMigration(Up20200704151301, Down20200704151301)
+func initialize20200704151301() {
+	if _, ok := initializedMigrations[20200704151301]; !ok {
+		goose.AddMigration(Up20200704151301, Down20200704151301)
+		initializedMigrations[20200704151301] = true
+	}
 }
 
 // Up20200704151301 updates the CVAT template to a new version.

--- a/db/go/db.go
+++ b/db/go/db.go
@@ -6,6 +6,10 @@ import (
 	v1 "github.com/onepanelio/core/pkg"
 )
 
+// initializedMigrations is used to keep track of which migrations have been initialized.
+// if they are initialzed more than once, goose panics.
+var initializedMigrations = make(map[int]bool)
+
 // Initialize sets up the go migrations.
 func Initialize() {
 	initialize20200525160514()
@@ -13,6 +17,7 @@ func Initialize() {
 	initialize20200605090509()
 	initialize20200605090535()
 	initialize20200626113635()
+	initialize20200704151301()
 }
 
 func getClient() (*v1.Client, error) {

--- a/pkg/config_types.go
+++ b/pkg/config_types.go
@@ -142,7 +142,7 @@ func (s SystemConfig) DatabaseConnection() (driverName, dataSourceName string) {
 func (s SystemConfig) UpdateNodePoolOptions(parameters []Parameter) ([]Parameter, error) {
 	result := make([]Parameter, 0)
 
-	var nodePoolParameter *Parameter = nil
+	var nodePoolParameter *Parameter
 
 	// Copy the original parameters, skipping sys-node-pool
 	for i := range parameters {

--- a/pkg/config_types.go
+++ b/pkg/config_types.go
@@ -136,6 +136,51 @@ func (s SystemConfig) DatabaseConnection() (driverName, dataSourceName string) {
 	return
 }
 
+// UpdateNodePoolOptions will update the sys-node-pool parameter's options with runtime values
+// The original slice is unmodified, the returned slice has the updated values
+// If sys-node-pool is not present, nothing happens.
+func (s SystemConfig) UpdateNodePoolOptions(parameters []Parameter) ([]Parameter, error) {
+	result := make([]Parameter, 0)
+
+	var nodePoolParameter *Parameter = nil
+
+	// Copy the original parameters, skipping sys-node-pool
+	for i := range parameters {
+		parameter := parameters[i]
+		if parameter.Name == "sys-node-pool" {
+			nodePoolParameter = &parameter
+			continue
+		}
+
+		result = append(result, parameter)
+	}
+
+	if nodePoolParameter == nil {
+		return result, nil
+	}
+
+	nodePoolOptions, err := s.NodePoolOptions()
+	if err != nil {
+		return result, err
+	}
+
+	options := make([]*ParameterOption, 0)
+	for _, option := range nodePoolOptions {
+		newOption := &ParameterOption{
+			Name:  option.Name,
+			Value: option.Value,
+		}
+
+		options = append(options, newOption)
+	}
+
+	nodePoolParameter.Options = options
+
+	result = append(result, *nodePoolParameter)
+
+	return result, nil
+}
+
 type ArtifactRepositoryS3Config struct {
 	KeyFormat       string
 	Bucket          string

--- a/server/workspace_server.go
+++ b/server/workspace_server.go
@@ -147,6 +147,11 @@ func (s *WorkspaceServer) GetWorkspace(ctx context.Context, req *api.GetWorkspac
 		return nil, err
 	}
 
+	templateParameters, err = sysConfig.UpdateNodePoolOptions(templateParameters)
+	if err != nil {
+		return nil, err
+	}
+
 	apiWorkspace.TemplateParameters = converter.ParametersToAPI(templateParameters)
 
 	return apiWorkspace, nil


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where get workspaces did not return up to date node pool options.
This is seen in the UI in the workspace details view page - in the node pool options in the bottom panel.

Fixes onepanelio/core#407

**Special notes for your reviewer**:

To test 
1. Start a workspace (any is good)
2. Wait until it is running
3. Go to the detail page, and open the bottom panel. Check the node pool options.
4. Edit your onepanel configmap node pool options and add an option (or remove)
5. Refresh the page and check the node pool options.
