### PR TITLE
fix: Adding omitempty to prevent the keys from showing up in onepanel

### DIFF
--- a/pkg/config_types.go
+++ b/pkg/config_types.go
@@ -3,11 +3,12 @@ package v1
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
+
 	"github.com/onepanelio/core/pkg/util/ptr"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 // SystemConfig is configuration loaded from kubernetes config and secrets that includes information about the
@@ -192,8 +193,8 @@ type ArtifactRepositoryS3Provider struct {
 	Region          string
 	AccessKeySecret ArtifactRepositorySecret `yaml:"accessKeySecret"`
 	SecretKeySecret ArtifactRepositorySecret `yaml:"secretKeySecret"`
-	AccessKey       string                   `yaml:"accessKey"`
-	Secretkey       string                   `yaml:"secretKey"`
+	AccessKey       string                   `yaml:"accessKey,omitempty"`
+	Secretkey       string                   `yaml:"secretKey,omitempty"`
 }
 
 // ArtifactRepositoryGCSProvider is meant to be used
@@ -206,7 +207,7 @@ type ArtifactRepositoryGCSProvider struct {
 	Insecure                bool
 	ServiceAccountKey       string                   `yaml:"serviceAccountKey,omitempty"`
 	ServiceAccountKeySecret ArtifactRepositorySecret `yaml:"serviceAccountKeySecret"`
-	ServiceAccountJSON      string                   `yaml:"omitempty"`
+	ServiceAccountJSON      string                   `yaml:"serviceAccountJSON,omitempty"`
 }
 
 // ArtifactRepositoryProvider is used to setup access into AWS Cloud Storage


### PR DESCRIPTION
configmap, if they are not filled.
- Adding explicit yaml conversion for serviceAccountJSON, otherwise
"omitempty" shows in the configmap.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:
