### PR TITLE
chore: simplify logic for parsing parameters from cron workflow manifests

### DIFF
--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Onepanel",
     "description": "Onepanel API",
-    "version": "0.12.0b3",
+    "version": "0.12.0b4",
     "contact": {
       "name": "Onepanel project",
       "url": "https://github.com/onepanelio/core"

--- a/pkg/common_types.go
+++ b/pkg/common_types.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"fmt"
-	"github.com/onepanelio/core/pkg/util/ptr"
 	"gopkg.in/yaml.v2"
 )
 
@@ -50,8 +49,9 @@ func IsValidParameters(parameters []Parameter) error {
 	return nil
 }
 
+// Arguments are the arguments in a manifest file.
 type Arguments struct {
-	Parameters []Parameter `json:"parameters" protobuf:"bytes,1,opt,name=parameters"`
+	Parameters []Parameter `json:"parameters"`
 }
 
 // WorkflowTemplateManifest is a client representation of a WorkflowTemplate
@@ -65,76 +65,6 @@ type WorkflowTemplateManifest struct {
 // This may be redundant with WorkflowTemplateManifest and should be looked at. # TODO
 type WorkflowExecutionSpec struct {
 	Arguments Arguments
-}
-
-// ParameterFromMap parses a parameter given a generic map of values
-// this should not be used anyway in favor of yaml marshaling/unmarshaling
-// left until it is refactored and tested
-// Deprecated
-func ParameterFromMap(paramMap map[interface{}]interface{}) *Parameter {
-	workflowParameter := Parameter{
-		Options: []*ParameterOption{},
-	}
-
-	// TODO choose a consistent way and use that.
-	if value, ok := paramMap["displayname"]; ok {
-		if displayName, ok := value.(string); ok {
-			workflowParameter.DisplayName = &displayName
-		}
-	} else if value, ok := paramMap["displayName"]; ok {
-		if displayName, ok := value.(string); ok {
-			workflowParameter.DisplayName = &displayName
-		}
-	}
-
-	if value, ok := paramMap["hint"]; ok {
-		if hint, ok := value.(string); ok {
-			workflowParameter.Hint = ptr.String(hint)
-		}
-	}
-
-	if value, ok := paramMap["required"]; ok {
-		if required, ok := value.(bool); ok {
-			workflowParameter.Required = required
-		}
-	}
-
-	if value, ok := paramMap["type"]; ok {
-		if typeValue, ok := value.(string); ok {
-			workflowParameter.Type = typeValue
-		}
-	}
-
-	if value, ok := paramMap["name"]; ok {
-		if nameValue, ok := value.(string); ok {
-			workflowParameter.Name = nameValue
-		}
-	}
-
-	if value, ok := paramMap["value"]; ok {
-		if valueValue, ok := value.(string); ok {
-			workflowParameter.Value = &valueValue
-		}
-	}
-
-	options := paramMap["options"]
-	optionsArray, ok := options.([]interface{})
-	if !ok {
-		return &workflowParameter
-	}
-
-	for _, option := range optionsArray {
-		optionMap := option.(map[interface{}]interface{})
-
-		newOption := ParameterOption{
-			Name:  optionMap["name"].(string),
-			Value: optionMap["value"].(string),
-		}
-
-		workflowParameter.Options = append(workflowParameter.Options, &newOption)
-	}
-
-	return &workflowParameter
 }
 
 // ParseParametersFromManifest takes a manifest and picks out the parameters and returns them as structs

--- a/pkg/cron_workflow_types_test.go
+++ b/pkg/cron_workflow_types_test.go
@@ -1,0 +1,113 @@
+package v1
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestCronWorkflow_GetParametersFromWorkflowSpec makes sure the GetParametersFromWorkflowSpec method works
+func TestCronWorkflow_GetParametersFromWorkflowSpec(t *testing.T) {
+	manifest := `concurrencyPolicy: Allow
+failedJobsHistoryLimit: 1
+schedule: '* * * * 2'
+startingDeadlineSeconds: 0
+successfulJobsHistoryLimit: 3
+suspend: false
+timezone: Etc/UTC
+workflowSpec:
+  arguments:
+    parameters:
+    - displayname: ""
+      hint: ""
+      name: source
+      options: []
+      required: false
+      type: ""
+      value: https://github.com/onepanelio/Mask_RCNN.git
+    - displayname: ""
+      hint: ""
+      name: dataset-path
+      options: []
+      required: false
+      type: ""
+      value: datasets/test_05142020170720
+    - displayname: ""
+      hint: ""
+      name: model-path
+      options: []
+      required: false
+      type: ""
+      value: models/rush/cvat6-20
+    - displayname: ""
+      hint: ""
+      name: extras
+      options: []
+      required: false
+      type: ""
+      value: none
+    - displayname: ""
+      hint: ""
+      name: task-name
+      options: []
+      required: false
+      type: ""
+      value: test
+    - displayname: ""
+      hint: ""
+      name: num-classes
+      options: []
+      required: false
+      type: ""
+      value: "2"
+    - displayname: ""
+      hint: ""
+      name: stage-1-epochs
+      options: []
+      required: false
+      type: ""
+      value: "1"
+    - displayname: ""
+      hint: ""
+      name: stage-2-epochs
+      options: []
+      required: false
+      type: ""
+      value: "2"
+    - displayname: ""
+      hint: ""
+      name: stage-3-epochs
+      options: []
+      required: false
+      type: ""
+      value: "3"
+    - displayname: ""
+      hint: ""
+      name: tf-image
+      options: []
+      required: false
+      type: ""
+      value: tensorflow/tensorflow:1.13.1-py3
+    - displayname: Node pool
+      hint: Name of node pool or group
+      name: sys-node-pool
+      options:
+      - name: 'CPU: 2, RAM: 8GB'
+        value: Standard_D2s_v3
+      - name: 'CPU: 4, RAM: 16GB'
+        value: Standard_D4s_v3
+      - name: 'GPU: 1xK80, CPU: 6, RAM: 56GB'
+        value: Standard_NC6
+      required: true
+      type: select.select
+      value: cake`
+
+	cronWorkflow := CronWorkflow{
+		Manifest: manifest,
+	}
+
+	parameters, err := cronWorkflow.GetParametersFromWorkflowSpec()
+	assert.Nil(t, err)
+	assert.NotNil(t, parameters)
+
+	assert.Len(t, parameters, 11)
+}

--- a/server/converter/converter.go
+++ b/server/converter/converter.go
@@ -4,6 +4,7 @@ import (
 	"github.com/onepanelio/core/api"
 	v1 "github.com/onepanelio/core/pkg"
 	"sort"
+	"time"
 )
 
 func APIKeyValueToLabel(apiKeyValues []*api.KeyValue) map[string]string {
@@ -76,13 +77,13 @@ func APIParameterOptionsToInternal(options []*api.ParameterOption) []*v1.Paramet
 	return result
 }
 
+// ParameterToAPI converts a v1.Parameter to a *api.Parameter
 func ParameterToAPI(param v1.Parameter) *api.Parameter {
 	apiParam := &api.Parameter{
 		Name:     param.Name,
 		Type:     param.Type,
 		Required: param.Required,
 	}
-
 	if param.Value != nil {
 		apiParam.Value = *param.Value
 	}
@@ -92,7 +93,9 @@ func ParameterToAPI(param v1.Parameter) *api.Parameter {
 	if param.Hint != nil {
 		apiParam.Hint = *param.Hint
 	}
-
+	if param.Visibility != nil {
+		apiParam.Visibility = *param.Visibility
+	}
 	if param.Options != nil {
 		apiParam.Options = ParameterOptionsToAPI(param.Options)
 	}
@@ -133,4 +136,14 @@ func APIParameterToInternal(param *api.Parameter) *v1.Parameter {
 	}
 
 	return result
+}
+
+// TimestampToAPIString converts a *time.Time to an API string in the RFC3339 format
+// if ts is nil, an empty string is returned
+func TimestampToAPIString(ts *time.Time) string {
+	if ts == nil {
+		return ""
+	}
+
+	return ts.UTC().Format(time.RFC3339)
 }

--- a/server/workflow_template_server.go
+++ b/server/workflow_template_server.go
@@ -17,25 +17,12 @@ func NewWorkflowTemplateServer() *WorkflowTemplateServer {
 	return &WorkflowTemplateServer{}
 }
 
+// apiWorkflowTemplate converts a *v1.WorkflowTemplate to a *api.WorkflowTemplate
 func apiWorkflowTemplate(wft *v1.WorkflowTemplate) *api.WorkflowTemplate {
-	var aParams []*api.Parameter
-	for _, p := range wft.Parameters {
-		ap := api.Parameter{
-			Name: p.Name,
-		}
-		if p.Value != nil {
-			ap.Value = *p.Value
-		}
-		if p.Visibility != nil {
-			ap.Visibility = *p.Visibility
-		}
-
-		aParams = append(aParams, &ap)
-	}
-
 	res := &api.WorkflowTemplate{
 		Uid:        wft.UID,
-		CreatedAt:  wft.CreatedAt.UTC().Format(time.RFC3339),
+		CreatedAt:  converter.TimestampToAPIString(&wft.CreatedAt),
+		ModifiedAt: converter.TimestampToAPIString(wft.ModifiedAt),
 		Name:       wft.Name,
 		Version:    wft.Version,
 		Versions:   wft.Versions,
@@ -43,11 +30,7 @@ func apiWorkflowTemplate(wft *v1.WorkflowTemplate) *api.WorkflowTemplate {
 		IsLatest:   wft.IsLatest,
 		IsArchived: wft.IsArchived,
 		Labels:     converter.MappingToKeyValue(wft.Labels),
-		Parameters: aParams,
-	}
-
-	if wft.ModifiedAt != nil {
-		res.ModifiedAt = wft.ModifiedAt.UTC().Format(time.RFC3339)
+		Parameters: converter.ParametersToAPI(wft.Parameters),
 	}
 
 	if wft.WorkflowExecutionStatisticReport != nil {


### PR DESCRIPTION
**What this PR does**:

Refactors parameter parsing for cron workflows from their manifest to use yaml unmarshaling, which is safer and cleaner.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#450

**Special notes for your reviewer**:
