### PR TITLE
fix: issue where downloading artifact files from a workflow over 10 MB failed

### DIFF
--- a/api/api.proto
+++ b/api/api.proto
@@ -19,6 +19,7 @@ option (grpc.gateway.protoc_gen_swagger.options.openapiv2_swagger) = {
 	schemes: HTTPS;
 	consumes: "application/json";
 	produces: "application/json";
+	produces: "application/octet-stream";
 	security_definitions: {
 		security: {
 			key: "Bearer";

--- a/api/api.swagger.json
+++ b/api/api.swagger.json
@@ -18,7 +18,8 @@
     "application/json"
   ],
   "produces": [
-    "application/json"
+    "application/json",
+    "application/octet-stream"
   ],
   "paths": {
     "/apis/v1beta1/auth": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Increases the server and client message size.
- Both receive and sending.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#414

**Special notes for your reviewer**:
To test, create a workflow that outputs a main.log file of over 10 MB.
Then try downloading it.
You should be able to download the file and not get any console errors in the browser.