### PR TITLE
fix: issue with migrations failing to run

### DIFF
--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -884,6 +884,7 @@ func (c *Client) CreateWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 	if err != nil {
 		return nil, util.NewUserError(codes.InvalidArgument, err.Error())
 	}
+	workspaceTemplate.Namespace = namespace
 
 	existingWorkspaceTemplate, err := c.getWorkspaceTemplateByName(namespace, workspaceTemplate.Name)
 	if err != nil {
@@ -967,6 +968,7 @@ func (c *Client) UpdateWorkspaceTemplate(namespace string, workspaceTemplate *Wo
 	}
 	workspaceTemplate.ID = existingWorkspaceTemplate.ID
 	workspaceTemplate.Name = existingWorkspaceTemplate.UID
+	workspaceTemplate.Namespace = existingWorkspaceTemplate.Namespace
 
 	updatedWorkflowTemplate, err := c.generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate)
 	if err != nil {


### PR DESCRIPTION
**What this PR does**:

Fix issue where workspaceTemplate namespace was not set before setting service environment variables
These were called from migrations

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:
