### PR TITLE
fix: add more useful error message when workflow template name is too long

### DIFF
--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"bufio"
 	"cloud.google.com/go/storage"
 	"database/sql"
 	"encoding/json"
@@ -969,10 +970,11 @@ func (c *Client) GetWorkflowExecutionLogs(namespace, uid, podName, containerName
 	logWatcher := make(chan *LogEntry)
 	go func() {
 		buffer := make([]byte, 4096)
+		reader := bufio.NewReader(stream)
 
 		newLine := true
 		for {
-			bytesRead, err := stream.Read(buffer)
+			bytesRead, err := reader.Read(buffer)
 			if err != nil && err.Error() != "EOF" {
 				break
 			}

--- a/pkg/workflow_template.go
+++ b/pkg/workflow_template.go
@@ -107,7 +107,7 @@ func createLatestWorkflowTemplateVersionDB(runner sq.BaseRunner, workflowTemplat
 // The returned WorkflowTemplate has the ArgoWorkflowTemplate set to the newly created one.
 func (c *Client) createWorkflowTemplate(namespace string, workflowTemplate *WorkflowTemplate) (*WorkflowTemplate, *WorkflowTemplateVersion, error) {
 	if err := workflowTemplate.GenerateUID(workflowTemplate.Name); err != nil {
-		return nil, nil, err
+		return nil, nil, util.NewUserError(codes.InvalidArgument, "Template name must be 30 characters or less")
 	}
 
 	tx, err := c.DB.Begin()


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where API did not return a useful error message when the workflow template name was too long (when creating or cloning).

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#458

**Special notes for your reviewer**:
