### PR TITLE
fix: Skip generation volume size parameters for system volumes

### DIFF
--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -173,6 +173,9 @@ func generateArguments(spec *WorkspaceSpec, config SystemConfig) (err error) {
 	}
 	// Volume size parameters
 	volumeClaimsMapped := make(map[string]bool)
+	// Don't generate parameters for system volumes volumeMounts
+	volumeClaimsMapped["sys-dshm"] = true
+	volumeClaimsMapped["sys-namespace-config"] = true
 	for _, c := range spec.Containers {
 		for _, v := range c.VolumeMounts {
 			// Skip if already mapped or storage size is set


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
Fixes an issue where volume size parameter was added for `sys-namespace-config` volume mount. The end user should not have the option to set a volume size for system volumes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->

**Special notes for your reviewer**:
To test, add the `sys-namespace-config` volume to a container as follows and check that a volume size parameter is not added:
```yaml
- name: filesyncer
  image: onepanel/filesyncer:s3
...
  volumeMounts:
  - name: sys-namespace-config
    mountPath: /etc/onepanel
    readOnly: true
...
```
