### PR TITLE
fix: Updating code that injects the location of the serviceAccountToken if Google Cloud Storage is used.

### DIFF
--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -130,7 +130,7 @@ func injectArtifactRepositoryConfig(artifact *wfv1.Artifact, namespaceConfig *Na
 		artifact.GCS.Bucket = gcsConfig.Bucket
 		artifact.GCS.Key = gcsConfig.KeyFormat
 		artifact.GCS.ServiceAccountKeySecret.Name = "onepanel"
-		artifact.GCS.ServiceAccountKeySecret.Key = "serviceAccountKey"
+		artifact.GCS.ServiceAccountKeySecret.Key = "artifactRepositoryGCSServiceAccountKey"
 	}
 
 	// Default to no compression for artifacts


### PR DESCRIPTION
- Otherwise, the workflow can't get access to GCS bucket.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#547

**Special notes for your reviewer**:
