### PR TITLE
feat: Updated Workflows, and Cron created Workflows, to ensure they get their own pod by using Pod AntiAffinity. This replaces resource limits and/or requests.

### DIFF
--- a/pkg/cron_workflow.go
+++ b/pkg/cron_workflow.go
@@ -429,11 +429,11 @@ func (c *Client) updateCronWorkflow(namespace string, uid string, workflowTempla
 }
 
 func (c *Client) createCronWorkflow(namespace string, workflowTemplateId *uint64, wf *wfv1.Workflow, cwf *wfv1.CronWorkflow, opts *WorkflowExecutionOptions) (createdCronWorkflow *wfv1.CronWorkflow, err error) {
+	wf = ensureWorkflowRunsOnDedicatedNode(wf)
 	cwf, err = c.buildCronWorkflowDefinition(namespace, workflowTemplateId, wf, cwf, opts)
 	if err != nil {
 		return
 	}
-
 	createdCronWorkflow, err = c.ArgoprojV1alpha1().CronWorkflows(namespace).Create(cwf)
 	if err != nil {
 		return nil, err

--- a/pkg/cron_workflow.go
+++ b/pkg/cron_workflow.go
@@ -429,7 +429,14 @@ func (c *Client) updateCronWorkflow(namespace string, uid string, workflowTempla
 }
 
 func (c *Client) createCronWorkflow(namespace string, workflowTemplateId *uint64, wf *wfv1.Workflow, cwf *wfv1.CronWorkflow, opts *WorkflowExecutionOptions) (createdCronWorkflow *wfv1.CronWorkflow, err error) {
-	wf = ensureWorkflowRunsOnDedicatedNode(wf)
+	systemConfig, err := c.GetSystemConfig()
+	if err != nil {
+		return nil, err
+	}
+	wf, err = ensureWorkflowRunsOnDedicatedNode(wf, systemConfig)
+	if err != nil {
+		return
+	}
 	cwf, err = c.buildCronWorkflowDefinition(namespace, workflowTemplateId, wf, cwf, opts)
 	if err != nil {
 		return

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -371,25 +371,18 @@ func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow, config SystemConfig) (
 			continue
 		}
 
-		var value string
-		for k, v := range template.NodeSelector {
-			if k == *config.NodePoolLabel() {
-				value = v
-				break
-			}
-		}
-		if value == "" {
-			continue
-		}
-		if strings.Contains(value, "{{workflow.") {
-			parts := strings.Split(strings.Replace(value, "}}", "", -1), ".")
-			paramName := parts[len(parts)-1]
-			for _, param := range wf.Spec.Arguments.Parameters {
-				if param.Name == paramName && param.Value != nil {
-					nodeSelectorVal = *param.Value
-					break
+		for _, v := range template.NodeSelector {
+			if strings.Contains(v, "{{workflow.") {
+				parts := strings.Split(strings.Replace(v, "}}", "", -1), ".")
+				paramName := parts[len(parts)-1]
+				for _, param := range wf.Spec.Arguments.Parameters {
+					if param.Name == paramName && param.Value != nil {
+						nodeSelectorVal = *param.Value
+						break
+					}
 				}
 			}
+			break
 		}
 		template.Metadata.Labels = map[string]string{antiAffinityLabelKey: nodeSelectorVal}
 		addPodAffinity = true

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -355,7 +355,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 	return
 }
 
-func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow) {
+func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow) *wfv1.Workflow {
 	antiAffinityLabelKey := "onepanel.io/reserves-instance-type"
 	nodeSelectorVal := "singular-workflow"
 	for i := range wf.Spec.Templates {
@@ -373,6 +373,7 @@ func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow) {
 			},
 		},
 	}
+	return wf
 }
 
 func (c *Client) ValidateWorkflowExecution(namespace string, manifest []byte) (err error) {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -325,7 +325,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 		return nil, err
 	}
 
-	ensureWorkflowRunsOnDedicatedNode(wf)
+	wf = ensureWorkflowRunsOnDedicatedNode(wf)
 	createdArgoWorkflow, err := c.ArgoprojV1alpha1().Workflows(namespace).Create(wf)
 	if err != nil {
 		return nil, err

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -364,7 +364,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow, config SystemConfig) (*wfv1.Workflow, error) {
 	antiAffinityLabelKey := "onepanel.io/reserves-instance-type"
 	nodeSelectorVal := ""
-
+	addPodAffinity := false
 	for i := range wf.Spec.Templates {
 		template := &wf.Spec.Templates[i]
 		if template.NodeSelector == nil {
@@ -392,6 +392,9 @@ func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow, config SystemConfig) (
 			}
 		}
 		template.Metadata.Labels = map[string]string{antiAffinityLabelKey: nodeSelectorVal}
+		addPodAffinity = true
+	}
+	if addPodAffinity {
 		wf.Spec.Affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -391,12 +391,14 @@ func ensureWorkflowRunsOnDedicatedNode(wf *wfv1.Workflow, config SystemConfig) (
 		wf.Spec.Affinity = &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					{LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{Key: antiAffinityLabelKey, Operator: "In", Values: []string{nodeSelectorVal}},
+					{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: antiAffinityLabelKey, Operator: "In", Values: []string{nodeSelectorVal}},
+							},
 						},
+						TopologyKey: "kubernetes.io/hostname",
 					},
-						TopologyKey: "kubernetes.io/hostname"},
 				},
 			},
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
This PR will ensure that only one workflow will be scheduled on a Node.
This way, that workflow will get the entire Node resources to execute.
- All the templates used by the workflow will get a dedicated Node. So multiple containers will get their own Node.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#583

**Special notes for your reviewer**:
The changes here may not exclude the situation where a Workspace shares a node with a Workflow.
Should I adjust the code to ensure a workspace does not share a node with a workflow?