### PR TITLE
fix: Do not try to calculate resource requests and limits if the node is not running.

### DIFF
--- a/pkg/workspace.go
+++ b/pkg/workspace.go
@@ -374,12 +374,18 @@ func generateExtraContainerWithResources(c *Client, labelKeyVal string, nodePool
 	return nil, nil
 }
 
-func CalculateResourceRequirements(node corev1.Node, labelKeyVal string, nodePoolVal string) (string, string, int64, string) {
+// CalculateResourceRequirements will take the passed in Node and try to figure out the
+// allocatable capacity. Once the capacity is discovered, function figures out how to request 90%.
+// - We use 90% because manual calculation is error prone and not necessarily reliable.
+// Params:
+//  k8sInstanceTypeLabel - Such as 'beta.kubernetes.io/instance-type'
+//  nodeSelectorValue - Server/VM Type Name, Such as "Standard_NC6", on Azure.
+func CalculateResourceRequirements(node corev1.Node, k8sInstanceTypeLabel string, nodeSelectorValue string) (string, string, int64, string) {
 	var cpu string
 	var memory string
 	var gpu int64
 	gpuManufacturer := ""
-	if node.Labels[labelKeyVal] == nodePoolVal {
+	if node.Labels[k8sInstanceTypeLabel] == nodeSelectorValue {
 		cpuInt := node.Status.Allocatable.Cpu().MilliValue()
 		cpu = strconv.FormatFloat(float64(cpuInt)*.9, 'f', 0, 64) + "m"
 		memoryInt := node.Status.Allocatable.Memory().MilliValue()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
This should fix Workspaces not starting because the "cpu" and "memory" request values are "".
- k8s throws a "cannot parse error"

If the node is not running, then we don't try to allocate the resource limits / requests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [X] I accept to release these changes under the Apache 2.0 License   