### PR TITLE
fix: use system-wide db connection for auth

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -57,6 +57,19 @@ func GetDefaultClient() (*Client, error) {
 	return client, nil
 }
 
+// GetDefaultClientWithDB loads a default k8s client with an existing DB
+func GetDefaultClientWithDB(db *DB) (*Client, error) {
+	kubeConfig := NewConfig()
+	client, err := NewClient(kubeConfig, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client.DB = db
+
+	return client, nil
+}
+
 // NewClient creates a client to interact with the Onepanel system.
 // It includes access to the database, kubernetes, argo, and configuration.
 func NewClient(config *Config, db *DB, systemConfig SystemConfig) (client *Client, err error) {

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -165,7 +165,7 @@ func UnaryInterceptor(kubeConfig *v1.Config, db *v1.DB, sysConfig v1.SystemConfi
 				return resp, errors.New("LogInRequest does not have correct request type")
 			}
 
-			defaultClient, err := v1.GetDefaultClient()
+			defaultClient, err := v1.GetDefaultClientWithDB(db)
 			if err != nil {
 				return nil, err
 			}
@@ -177,10 +177,6 @@ func UnaryInterceptor(kubeConfig *v1.Config, db *v1.DB, sysConfig v1.SystemConfi
 
 			sysConfig, err := defaultClient.GetSystemConfig()
 			if err != nil {
-				return nil, err
-			}
-
-			if err := defaultClient.DB.Close(); err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
**What this PR does**:

Use a system-wide db connection for the auth check.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   