### PR TITLE
fix: change notify slack channel to be org instead of dev

### DIFF
--- a/.github/workflows/push_tag.yaml
+++ b/.github/workflows/push_tag.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Notify Slack Channels
         uses: rtCamp/action-slack-notify@v2.0.0
         env:
-          SLACK_CHANNEL: dev
+          SLACK_CHANNEL: org
           SLACK_ICON: https://avatars1.githubusercontent.com/u/30390575?s=48&v=4
           SLACK_TITLE: New Core Version
           SLACK_USERNAME: opBot


### PR DESCRIPTION
**What this PR does**:

Changes the slack channel notified of new build tags to be 'org' instead of 'dev'.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   