### PR TITLE
fix: non-generic filesyncer for latest cvat migration

### DIFF
--- a/db/data/cvat_20201016170415.yaml
+++ b/db/data/cvat_20201016170415.yaml
@@ -73,7 +73,7 @@ containers:
         name: http
   # You can add multiple FileSyncer sidecar containers if needed
   - name: filesyncer
-    image: onepanel/filesyncer:s3
+    image: onepanel/filesyncer:{{.ArtifactRepositoryType}}
     imagePullPolicy: Always
     args:
       - download


### PR DESCRIPTION
**What this PR does**:

Fixes an issue where latest cvat migration had a hard-coded filesyncer.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   