### PR TITLE
feat: Add support for visualization sidecars

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
 	github.com/golang/protobuf v1.4.1
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/handlers v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.4

--- a/go.mod
+++ b/go.mod
@@ -44,5 +44,4 @@ require (
 	k8s.io/apimachinery v0.16.7-beta.0
 	k8s.io/client-go v0.16.4
 	sigs.k8s.io/yaml v1.2.0
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -565,6 +565,9 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 			//routes
 			virtualServiceNameUUID := "vs-" + uuid.New().String()
 			hosts := []string{serviceName}
+			wf.Spec.Templates[tIdx].Outputs.Parameters = append(wf.Spec.Templates[tIdx].Outputs.Parameters,
+				wfv1.Parameter{Name: "sys-sidecar-url--" + s.Name, Value: &serviceName},
+			)
 			virtualService := map[string]interface{}{
 				"apiVersion": "networking.istio.io/v1alpha3",
 				"kind":       "VirtualService",

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -279,12 +279,13 @@ func (c *Client) injectAutomatedFields(namespace string, wf *wfv1.Workflow, opts
 			template.Metadata.Annotations = make(map[string]string)
 		}
 		template.Metadata.Annotations["sidecar.istio.io/inject"] = "false"
-		//todo not sure if we need istio yet
-		if template.Metadata.Labels != nil {
-			if sidecar, ok := template.Metadata.Labels["sidecar"]; ok {
-				if sidecar == "sys-visualization-sidecar" {
-					template.Metadata.Annotations["sidecar.istio.io/inject"] = "true"
-				}
+		//For workflows with accessible sidecars, we need istio
+		//Istio does not prevent the main container from stopping
+		for _, s := range template.Sidecars {
+			if s.TTY == true {
+				template.Metadata.Annotations["sidecar.istio.io/inject"] = "true"
+				//Only need one instance to require istio injection
+				break
 			}
 		}
 

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -418,7 +418,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 			if sidecar, ok := t.Metadata.Labels["sidecar"]; ok {
 				if sidecar == "sys-visualization-sidecar" {
 					//Inject services, virtual routes
-					for sIdx, s := range t.Sidecars {
+					for _, s := range t.Sidecars {
 						if len(s.Ports) == 0 {
 							msg := fmt.Sprintf("sidecar %s must have at least one port.", s.Name)
 							return nil, util.NewUserError(codes.InvalidArgument, msg)
@@ -473,16 +473,6 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								Kind:       "Service",
 							},
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "{{workflow.uid}}",
-								OwnerReferences: []metav1.OwnerReference{
-									{
-										APIVersion:         "argoproj.io/v1alpha1",
-										Kind:               "Workflow",
-										Name:               "{{workflow.name}}",
-										UID:                "{{workflow.uid}}",
-										BlockOwnerDeletion: ptr.Bool(true),
-									},
-								},
 								Name: serviceNameUidDNSCompliant,
 							},
 							Spec: corev1.ServiceSpec{
@@ -505,9 +495,8 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								},
 							},
 							Resource: &wfv1.ResourceTemplate{
-								Action:            "create",
-								SetOwnerReference: true,
-								Manifest:          serviceManifest,
+								Action:   "create",
+								Manifest: serviceManifest,
 							},
 						}
 						newTemplateOrder = append(newTemplateOrder, templateServiceResource)
@@ -518,16 +507,6 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 							"apiVersion": "networking.istio.io/v1alpha3",
 							"kind":       "VirtualService",
 							"metadata": metav1.ObjectMeta{
-								Name: "{{workflow.uid}}",
-								OwnerReferences: []metav1.OwnerReference{
-									{
-										APIVersion:         "argoproj.io/v1alpha1",
-										Kind:               "Workflow",
-										Name:               "{{workflow.name}}",
-										UID:                "{{workflow.uid}}",
-										BlockOwnerDeletion: ptr.Bool(true),
-									},
-								},
 								Name: virtualServiceNameUUID,
 							},
 							"spec": networking.VirtualService{
@@ -551,9 +530,8 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								},
 							},
 							Resource: &wfv1.ResourceTemplate{
-								Action:            "create",
-								Manifest:          virtualServiceManifest,
-								SetOwnerReference: true,
+								Action:   "create",
+								Manifest: virtualServiceManifest,
 							},
 						}
 						newTemplateOrder = append(newTemplateOrder, templateRouteResource)

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -435,13 +435,13 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 				return nil, util.NewUserError(codes.InvalidArgument, msg)
 			}
 
-			serviceNameUid := "s" + uuid.New().String() + "-" + namespace
-			serviceNameUidDNSCompliant, err := uid2.GenerateUID(serviceNameUid, 63)
+			serviceNameUID := "s" + uuid.New().String() + "-" + namespace
+			serviceNameUIDDNSCompliant, err := uid2.GenerateUID(serviceNameUID, 63)
 			if err != nil {
 				return nil, util.NewUserError(codes.InvalidArgument, err.Error())
 			}
 
-			serviceName := serviceNameUidDNSCompliant + "." + *c.systemConfig.Domain()
+			serviceName := serviceNameUIDDNSCompliant + "." + *c.systemConfig.Domain()
 
 			serviceTemplateName := "k8s-service-template-" + uuid.New().String()
 			serviceTaskName := "add-service-" + uuid.New().String()
@@ -469,7 +469,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 					Route: []*networking.HTTPRouteDestination{
 						{
 							Destination: &networking.Destination{
-								Host: serviceNameUidDNSCompliant,
+								Host: serviceNameUIDDNSCompliant,
 								Port: &networking.PortSelector{
 									Number: uint32(port.ContainerPort),
 								},
@@ -485,12 +485,12 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 					Kind:       "Service",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: serviceNameUidDNSCompliant,
+					Name: serviceNameUIDDNSCompliant,
 				},
 				Spec: corev1.ServiceSpec{
 					Ports: servicePorts,
 					Selector: map[string]string{
-						"app": serviceNameUidDNSCompliant,
+						"app": serviceNameUIDDNSCompliant,
 					},
 				},
 			}
@@ -498,7 +498,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 			if wf.Spec.Templates[tIdx].Metadata.Labels == nil {
 				wf.Spec.Templates[tIdx].Metadata.Labels = make(map[string]string)
 			}
-			wf.Spec.Templates[tIdx].Metadata.Labels["app"] = serviceNameUidDNSCompliant
+			wf.Spec.Templates[tIdx].Metadata.Labels["app"] = serviceNameUIDDNSCompliant
 			serviceManifestBytes, err := yaml2.Marshal(service)
 			if err != nil {
 				return nil, err

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -513,7 +513,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 							"spec": networking.VirtualService{
 								Http:     routes,
 								Gateways: []string{"istio-system/ingressgateway"},
-								Hosts:    []string{"{{workflow.parameters.sys-host}}"},
+								Hosts:    []string{"{{workflow.uid}}"},
 							},
 						}
 

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -461,7 +461,7 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 	taskSysSendExitStats := "sys-send-exit-stats"
 	for tIdx, t := range wf.Spec.Templates {
 		//Inject services, virtual routes
-		for _, s := range t.Sidecars {
+		for si, s := range t.Sidecars {
 			//If TTY is true, sidecar needs to be accessible by HTTP
 			//Otherwise, we skip the sidecar
 			if s.TTY != true {
@@ -472,6 +472,7 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 				return nil, util.NewUserError(codes.InvalidArgument, msg)
 			}
 
+			t.Sidecars[si].MirrorVolumeMounts = ptr.Bool(true)
 			serviceNameUID := "s" + uuid.New().String() + "--" + namespace
 			serviceNameUIDDNSCompliant, err := uid2.GenerateUID(serviceNameUID, 63)
 			if err != nil {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -552,7 +552,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								for it, t := range tasks {
 									for _, d := range t.Dependencies {
 										if d == "sys-send-status" {
-											wf.Spec.Templates[i2].DAG.Tasks[it].Dependencies = []string{d, "k8s-service-resource", "k8s-routes-resource"}
+											wf.Spec.Templates[i2].DAG.Tasks[it].Dependencies = []string{d, "k8s-services-resource", "k8s-routes-resource"}
 										}
 									}
 								}

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -682,7 +682,7 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 						for dti, dt := range t.DAG.Tasks {
 							if dt.Name == taskSysSendExitStats {
 								sysExitDepFound = true
-								t.DAG.Tasks[dti].Dependencies = []string{virtualServiceDeleteTaskName}
+								t.DAG.Tasks[dti].Dependencies = append(t.DAG.Tasks[dti].Dependencies, virtualServiceDeleteTaskName)
 							}
 						}
 						if sysExitDepFound == false {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -435,7 +435,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 				return nil, util.NewUserError(codes.InvalidArgument, msg)
 			}
 
-			serviceNameUID := "s" + uuid.New().String() + "-" + namespace
+			serviceNameUID := "s" + uuid.New().String() + "--" + namespace
 			serviceNameUIDDNSCompliant, err := uid2.GenerateUID(serviceNameUID, 63)
 			if err != nil {
 				return nil, util.NewUserError(codes.InvalidArgument, err.Error())

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -279,6 +279,14 @@ func (c *Client) injectAutomatedFields(namespace string, wf *wfv1.Workflow, opts
 			template.Metadata.Annotations = make(map[string]string)
 		}
 		template.Metadata.Annotations["sidecar.istio.io/inject"] = "false"
+		//todo not sure if we need istio yet
+		if template.Metadata.Labels != nil {
+			if sidecar, ok := template.Metadata.Labels["sidecar"]; ok {
+				if sidecar == "sys-visualization-sidecar" {
+					template.Metadata.Annotations["sidecar.istio.io/inject"] = "true"
+				}
+			}
+		}
 
 		if template.Container != nil {
 			// Mount dev/shm

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -485,6 +485,11 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 						serviceManifest := string(serviceManifestBytes)
 						templateServiceResource := wfv1.Template{
 							Name: "k8s-services-resource",
+							Metadata: wfv1.Metadata{
+								Annotations: map[string]string{
+									"sidecar.istio.io/inject": "false",
+								},
+							},
 							Resource: &wfv1.ResourceTemplate{
 								Action:           "create",
 								SuccessCondition: "status.succeeded > 0",
@@ -525,6 +530,11 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 
 						templateRouteResource := wfv1.Template{
 							Name: "k8s-routes-resource",
+							Metadata: wfv1.Metadata{
+								Annotations: map[string]string{
+									"sidecar.istio.io/inject": "false",
+								},
+							},
 							Resource: &wfv1.ResourceTemplate{
 								Action:           "create",
 								SuccessCondition: "status.succeeded > 0",

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -491,10 +491,9 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								},
 							},
 							Resource: &wfv1.ResourceTemplate{
-								Action:           "create",
-								SuccessCondition: "status.succeeded > 0",
-								FailureCondition: "status.failed > 3",
-								Manifest:         serviceManifest,
+								Action:            "create",
+								SetOwnerReference: true,
+								Manifest:          serviceManifest,
 							},
 						}
 						newTemplateOrder = append(newTemplateOrder, templateServiceResource)
@@ -536,10 +535,9 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								},
 							},
 							Resource: &wfv1.ResourceTemplate{
-								Action:           "create",
-								SuccessCondition: "status.succeeded > 0",
-								FailureCondition: "status.failed > 3",
-								Manifest:         virtualServiceManifest,
+								Action:            "create",
+								Manifest:          virtualServiceManifest,
+								SetOwnerReference: true,
 							},
 						}
 						newTemplateOrder = append(newTemplateOrder, templateRouteResource)

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -437,7 +437,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 									{
 										Uri: &networking.StringMatch{
 											MatchType: &networking.StringMatch_Prefix{
-												Prefix: "/sys/" + strconv.Itoa(sIdx) + "/" + s.Name},
+												Prefix: "/"},
 										},
 									},
 								},

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/watch"
 	"net/http"
+	yaml2 "sigs.k8s.io/yaml"
 	"strconv"
 	"strings"
 	"time"
@@ -477,7 +478,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								},
 							},
 						}
-						serviceManifestBytes, err := yaml.Marshal(service)
+						serviceManifestBytes, err := yaml2.Marshal(service)
 						if err != nil {
 							return nil, err
 						}
@@ -516,7 +517,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 							},
 						}
 
-						virtualServiceManifestBytes, err := yaml.Marshal(virtualService)
+						virtualServiceManifestBytes, err := yaml2.Marshal(virtualService)
 						if err != nil {
 							return nil, err
 						}

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -411,7 +411,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 		return nil, err
 	}
 
-	newTemplateOrder := []wfv1.Template{}
+	var newTemplateOrder []wfv1.Template
 	for tIdx, t := range wf.Spec.Templates {
 		if t.Metadata.Labels != nil {
 			if sidecar, ok := t.Metadata.Labels["sidecar"]; ok {
@@ -422,8 +422,8 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 							msg := fmt.Sprintf("sidecar %s must have at least one port.", s.Name)
 							return nil, util.NewUserError(codes.InvalidArgument, msg)
 						}
-						servicePorts := []corev1.ServicePort{}
-						routes := []*networking.HTTPRoute{}
+						var servicePorts []corev1.ServicePort
+						var routes []*networking.HTTPRoute
 						for _, port := range s.Ports {
 							servicePort := corev1.ServicePort{
 								Name:       port.Name,

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	sq "github.com/Masterminds/squirrel"
+	"github.com/google/uuid"
 	"github.com/onepanelio/core/pkg/util/gcs"
 	"github.com/onepanelio/core/pkg/util/label"
 	"github.com/onepanelio/core/pkg/util/ptr"

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -479,17 +479,17 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 			serviceName := serviceNameUIDDNSCompliant + "." + *c.systemConfig.Domain()
 
 			serviceTemplateName := uuid.New().String()
-			serviceTemplateNameAdd := "k8s-service-template-add-" + serviceTemplateName
-			serviceTemplateNameDelete := "k8s-service-template-delete-" + serviceTemplateName
+			serviceTemplateNameAdd := "sys-k8s-service-template-add-" + serviceTemplateName
+			serviceTemplateNameDelete := "sys-k8s-service-template-delete-" + serviceTemplateName
 			serviceTaskName := "service-" + uuid.New().String()
-			serviceAddTaskName := "add-" + serviceTaskName
-			serviceDeleteTaskName := "delete-" + serviceTaskName
+			serviceAddTaskName := "sys-add-" + serviceTaskName
+			serviceDeleteTaskName := "sys-delete-" + serviceTaskName
 			virtualServiceTemplateName := uuid.New().String()
-			virtualServiceTemplateNameAdd := "k8s-virtual-service-template-add-" + virtualServiceTemplateName
-			virtualServiceTemplateNameDelete := "k8s-virtual-service-template-delete-" + virtualServiceTemplateName
+			virtualServiceTemplateNameAdd := "sys-k8s-virtual-service-template-add-" + virtualServiceTemplateName
+			virtualServiceTemplateNameDelete := "sys-k8s-virtual-service-template-delete-" + virtualServiceTemplateName
 			virtualServiceTaskName := "virtual-service-" + uuid.New().String()
-			virtualServiceAddTaskName := "add-" + virtualServiceTaskName
-			virtualServiceDeleteTaskName := "delete-" + virtualServiceTaskName
+			virtualServiceAddTaskName := "sys-add-" + virtualServiceTaskName
+			virtualServiceDeleteTaskName := "sys-delete-" + virtualServiceTaskName
 			var servicePorts []corev1.ServicePort
 			var routes []*networking.HTTPRoute
 			for _, port := range s.Ports {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -429,7 +429,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 								Name:       port.Name,
 								Protocol:   port.Protocol,
 								Port:       port.ContainerPort,
-								TargetPort: intstr.FromInt(int(port.HostPort)),
+								TargetPort: intstr.FromInt(int(port.ContainerPort)),
 							}
 							servicePorts = append(servicePorts, servicePort)
 							route := networking.HTTPRoute{

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -415,7 +415,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 	for tIdx, t := range wf.Spec.Templates {
 		if t.Metadata.Labels != nil {
 			if sidecar, ok := t.Metadata.Labels["sidecar"]; ok {
-				if sidecar == "sys-tensorboard-like" {
+				if sidecar == "sys-visualization-sidecar" {
 					//Inject services, virtual routes
 					for sIdx, s := range t.Sidecars {
 						if len(s.Ports) == 0 {

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -561,7 +561,7 @@ func (c *Client) injectAccessForSidecars(namespace string, wf *wfv1.Workflow) ([
 			}
 			newTemplateOrder = append(newTemplateOrder, templateServiceResource)
 			//routes
-			virtualServiceNameUUID := "{{workflow.uid}}-" + uuid.New().String()
+			virtualServiceNameUUID := "vs-" + uuid.New().String()
 			hosts := []string{serviceName}
 			virtualService := map[string]interface{}{
 				"apiVersion": "networking.istio.io/v1alpha3",

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -498,7 +498,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 				Spec: corev1.ServiceSpec{
 					Ports: servicePorts,
 					Selector: map[string]string{
-						"app": serviceNameUIDDNSCompliant,
+						serviceTaskName: serviceNameUIDDNSCompliant,
 					},
 				},
 			}
@@ -506,7 +506,7 @@ func (c *Client) createWorkflow(namespace string, workflowTemplateID uint64, wor
 			if wf.Spec.Templates[tIdx].Metadata.Labels == nil {
 				wf.Spec.Templates[tIdx].Metadata.Labels = make(map[string]string)
 			}
-			wf.Spec.Templates[tIdx].Metadata.Labels["app"] = serviceNameUIDDNSCompliant
+			wf.Spec.Templates[tIdx].Metadata.Labels[serviceTaskName] = serviceNameUIDDNSCompliant
 			serviceManifestBytes, err := yaml2.Marshal(service)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
- Specifically, if a sidecar is labeled with "sys-tensorboard-like",
code attempts to create services and virtual services (routes).
- Code will create argo templates that are resource type, where the
manifests are the generated resources.
The templates are then added right before the template with the
sidecar that requires these services and routes.

<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   