### PR TITLE
fix: concurrency issues with token

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -19,6 +19,7 @@ type Config = rest.Config
 var sb = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 type Client struct {
+	Token string
 	kubernetes.Interface
 	argoprojV1alpha1 argoprojv1alpha1.ArgoprojV1alpha1Interface
 	*DB

--- a/pkg/config_types.go
+++ b/pkg/config_types.go
@@ -3,13 +3,12 @@ package v1
 import (
 	"encoding/base64"
 	"fmt"
-	"strings"
-
 	"github.com/onepanelio/core/pkg/util/ptr"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	k8yaml "sigs.k8s.io/yaml"
+	"strings"
 )
 
 // SystemConfig is configuration loaded from kubernetes config and secrets that includes information about the

--- a/server/auth/auth.go
+++ b/server/auth/auth.go
@@ -85,9 +85,8 @@ func getClient(ctx context.Context, kubeConfig *v1.Config, db *v1.DB, sysConfig 
 	if !ok {
 		return nil, status.Error(codes.Unauthenticated, `Missing or invalid "authorization" header.`)
 	}
-
-	if sysConfig["token"] != *bearerToken {
-		sysConfig["token"] = *bearerToken
+	if bearerToken == nil {
+		return nil, status.Error(codes.Unauthenticated, "Bearer token is nil")
 	}
 
 	kubeConfig.BearerToken = *bearerToken
@@ -96,6 +95,7 @@ func getClient(ctx context.Context, kubeConfig *v1.Config, db *v1.DB, sysConfig 
 	if err != nil {
 		return nil, err
 	}
+	client.Token = kubeConfig.BearerToken
 
 	return context.WithValue(ctx, ContextClientKey, client), nil
 }

--- a/server/auth_server.go
+++ b/server/auth_server.go
@@ -68,7 +68,7 @@ func (a *AuthServer) IsValidToken(ctx context.Context, req *api.IsValidTokenRequ
 	}
 	res = &api.IsValidTokenResponse{
 		Domain: config["ONEPANEL_DOMAIN"],
-		Token:  config["token"],
+		Token:  client.Token,
 	}
 
 	return res, nil


### PR DESCRIPTION
**What this PR does**:

Moves token to be inside client instead of sysconfig as it is not a system config value, but it is applicable to the current client.

This fixes some concurrency issues since you could have multiple requests handled at the same time that try to read and modify the system values.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   