### PR TITLE
fix: reserved system name checks when creating templates

### DIFF
--- a/pkg/system.go
+++ b/pkg/system.go
@@ -1,0 +1,16 @@
+package v1
+
+import (
+	"github.com/onepanelio/core/pkg/util"
+	"google.golang.org/grpc/codes"
+)
+
+// ConvertToSystemName converts a name to a system name by prefixing it with "sys-"
+func ConvertToSystemName(name string) string {
+	return "sys-" + name
+}
+
+// NameReservedForSystemError is an error returned whenever the user tries to use a name reserved for the system
+func NameReservedForSystemError() error {
+	return &util.UserError{Code: codes.InvalidArgument, Message: "Names prefixed with 'sys-' are reserved by the system"}
+}

--- a/pkg/workspace_template.go
+++ b/pkg/workspace_template.go
@@ -1000,8 +1000,10 @@ func (c *Client) generateWorkspaceTemplateWorkflowTemplate(workspaceTemplate *Wo
 	workflowTemplateManifest = strings.NewReplacer(
 		"{{workspace.parameters.", "{{workflow.parameters.").Replace(workflowTemplateManifest)
 
+	// a workspace template's associated workflow template name should have a sys- prefix
+	// as it is system generated
 	workflowTemplate = &WorkflowTemplate{
-		Name:     workspaceTemplate.Name,
+		Name:     ConvertToSystemName(workspaceTemplate.Name),
 		Manifest: workflowTemplateManifest,
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	v1 "github.com/onepanelio/core/pkg"
 	"github.com/onepanelio/core/server/auth"
+	"strings"
 )
 
 const (
@@ -12,4 +13,9 @@ const (
 
 func getClient(ctx context.Context) *v1.Client {
 	return ctx.Value(auth.ContextClientKey).(*v1.Client)
+}
+
+// IsNameReservedForSystem returns true if the name is reserved for the system
+func IsNameReservedForSystem(name string) bool {
+	return strings.HasPrefix(name, "sys-")
 }

--- a/server/workflow_template_server.go
+++ b/server/workflow_template_server.go
@@ -50,6 +50,11 @@ func (s *WorkflowTemplateServer) CreateWorkflowTemplate(ctx context.Context, req
 	if err != nil || !allowed {
 		return nil, err
 	}
+
+	if IsNameReservedForSystem(req.WorkflowTemplate.Name) {
+		return nil, v1.NameReservedForSystemError()
+	}
+
 	workflowTemplate := &v1.WorkflowTemplate{
 		Name:     req.WorkflowTemplate.Name,
 		Manifest: req.WorkflowTemplate.Manifest,
@@ -59,6 +64,7 @@ func (s *WorkflowTemplateServer) CreateWorkflowTemplate(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
+
 	req.WorkflowTemplate.Uid = workflowTemplate.UID
 	req.WorkflowTemplate.Version = workflowTemplate.Version
 

--- a/server/workspace_template_server.go
+++ b/server/workspace_template_server.go
@@ -74,6 +74,10 @@ func (s *WorkspaceTemplateServer) CreateWorkspaceTemplate(ctx context.Context, r
 		return nil, err
 	}
 
+	if IsNameReservedForSystem(req.WorkspaceTemplate.Name) {
+		return nil, v1.NameReservedForSystemError()
+	}
+
 	workspaceTemplate := &v1.WorkspaceTemplate{
 		Namespace:   req.Namespace,
 		Name:        req.WorkspaceTemplate.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

Updated workspace templates' associated workflow templates to have a sys- prefix to indicate it is a system resource.

Also added checks to workflow/workspace template creation so they don't allow sys- prefixes.

**Which issue(s) this PR fixes**:
Fixes onepanelio/core#256

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   