### PR TITLE
feat: update kubernetes timeout to be set via environment variable

### DIFF
--- a/pkg/util/env/env.go
+++ b/pkg/util/env/env.go
@@ -10,7 +10,17 @@ const (
 	DefaultEnvironmentVariableSecret = "onepanel-default-env"
 )
 
+// GetEnv gets the environment variable value, or returns fallback if the environment variable does not exist
+// Deprecated: use Get instead
 func GetEnv(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}
+
+// Get gets the environment variable value, or returns fallback if the environment variable does not exist
+func Get(key, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
 		return value
 	}


### PR DESCRIPTION
**What this PR does**:

Update kubernetes timeout to be set via environment variable

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   