### PR TITLE
fix: adjust curl to use specific version and fail on non 200 responses

### DIFF
--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -1949,17 +1949,18 @@ with statistics about the workflow that was just executed.
 func getCURLNodeTemplate(name, curlMethod, curlPath, curlBody string, inputs wfv1.Inputs) (template *wfv1.Template, err error) {
 	host := "onepanel-core.onepanel.svc.cluster.local"
 	endpoint := fmt.Sprintf("http://%s%s", host, curlPath)
+
 	template = &wfv1.Template{
 		Name:   name,
 		Inputs: inputs,
 		Container: &corev1.Container{
 			Name:    "curl",
-			Image:   "curlimages/curl",
+			Image:   "curlimages/curl:7.73.0",
 			Command: []string{"sh", "-c"},
 			Args: []string{
 				"SERVICE_ACCOUNT_TOKEN=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token) " +
 					"&& curl -X " + curlMethod + " -s -o /dev/null -w '%{http_code}' " +
-					"--connect-timeout 10 --retry 5 --retry-delay 5 " +
+					"--connect-timeout 10 --retry 10 --retry-delay 5 --retry-all-errors --fail " +
 					"'" + endpoint + "' -H \"Content-Type: application/json\" -H 'Connection: keep-alive' -H 'Accept: application/json' " +
 					"-H 'Authorization: Bearer '\"$SERVICE_ACCOUNT_TOKEN\"'' " +
 					"--data '" + curlBody + "' --compressed",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:

Adjusts curl so a specific version is used. Changes the functionality so all errors, even 4xx ones are retried, and if a non 2xx response is returned, cause the container to error out instead of continuing successfully. Also increased retries in case of longer network errors. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   