### PR TITLE
fix: Set jupyterlab workingDir to /data

### DIFF
--- a/db/yaml/jupyterlab/20201214133458.yaml
+++ b/db/yaml/jupyterlab/20201214133458.yaml
@@ -3,6 +3,7 @@ containers:
   - name: jupyterlab
     image: onepanel/jupyterlab:1.0.1
     command: ["/bin/bash", "-c", "pip install onepanel-sdk && start.sh LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64 jupyter lab --LabApp.token='' --LabApp.allow_remote_access=True --LabApp.allow_origin=\"*\" --LabApp.disable_check_xsrf=True --LabApp.trust_xheaders=True --LabApp.base_url=/ --LabApp.tornado_settings='{\"headers\":{\"Content-Security-Policy\":\"frame-ancestors * \'self\'\"}}' --notebook-dir='/data' --allow-root"]
+    workingDir: /data
     env:
       - name: tornado
         value: "'{'headers':{'Content-Security-Policy':\"frame-ancestors\ *\ \'self'\"}}'"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:
1. Please read our contributor guidelines: https://docs.onepanel.ai/docs/getting-started/contributing
2. Prefix the title of this PR with `feat:`, `fix:`, `docs:` or `chore:`, example: `feat: added great feature`
3. If this PR is a feature or enhancement, then create an issue (https://github.com/onepanelio/core/issues) first. 
-->

**What this PR does**:
This fixes an issue where JupyterLab terminal would not open in the `/data` directory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes onepanelio/core#<issue-number>`
-->
Fixes onepanelio/core#

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   