### PR TITLE
fix: closing web sockets

### DIFF
--- a/db/go/20201214133458_fix_jupyterlab_gpu.go
+++ b/db/go/20201214133458_fix_jupyterlab_gpu.go
@@ -9,6 +9,7 @@ import (
 func initialize20201214133458() {
 	if _, ok := initializedMigrations[20201214133458]; !ok {
 		goose.AddMigration(Up20201214133458, Down20201214133458)
+		initializedMigrations[20201214133458] = true
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	k8runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"math"
 	"net"
@@ -55,7 +56,7 @@ func main() {
 			log.Fatalf("Failed to connect to Kubernetes cluster: %v", err)
 		}
 
-		go watchConfigmapChanges(client, "onepanel", stopCh, func(configMap *corev1.ConfigMap) error {
+		go watchConfigmapChanges("onepanel", stopCh, func(configMap *corev1.ConfigMap) error {
 			log.Printf("Configmap changed")
 			stopCh <- struct{}{}
 
@@ -214,7 +215,12 @@ func registerHandler(register registerFunc, ctx context.Context, mux *runtime.Se
 }
 
 // watchConfigmapChanges sets up a listener for configmap changes and calls the onChange function when it happens
-func watchConfigmapChanges(client *v1.Client, namespace string, stopCh <-chan struct{}, onChange func(*corev1.ConfigMap) error) {
+func watchConfigmapChanges(namespace string, stopCh <-chan struct{}, onChange func(*corev1.ConfigMap) error) {
+	client, err := kubernetes.NewForConfig(v1.NewConfig())
+	if err != nil {
+		return
+	}
+
 	restClient := client.CoreV1().RESTClient()
 	resource := "configmaps"
 	fieldSelector := fields.ParseSelectorOrDie(fmt.Sprintf("metadata.name=%s", "onepanel"))
@@ -235,6 +241,7 @@ func watchConfigmapChanges(client *v1.Client, namespace string, stopCh <-chan st
 			VersionedParams(&options, apiv1.ParameterCodec)
 		return req.Watch()
 	}
+
 	source := &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 	_, controller := cache.NewInformer(
 		source,

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -156,12 +156,12 @@ func (c *Client) GetWebRouter() (router.Web, error) {
 // It uses the KUBERNETES_TIMEOUT environment variable and defaults to 60 seconds if not found or an error occurs
 // parsing the set timeout.
 func getKubernetesTimeout() time.Duration {
-	timeoutSeconds := env.Get("KUBERNETES_TIMEOUT", "60")
+	timeoutSeconds := env.Get("KUBERNETES_TIMEOUT", "180")
 
 	timeout, err := strconv.Atoi(timeoutSeconds)
 	if err != nil {
 		log.Warn("Unable to parse KUBERNETES_TIMEOUT environment variable. Defaulting to 60 seconds")
-		return 60 * time.Second
+		return 180 * time.Second
 	}
 
 	return time.Duration(timeout) * time.Second

--- a/pkg/workflow_execution.go
+++ b/pkg/workflow_execution.go
@@ -1143,7 +1143,7 @@ func (c *Client) WatchWorkflowExecution(namespace, uid string) (<-chan *Workflow
 							break
 						}
 
-						timeouts += 1
+						timeouts++
 						continue
 					}
 


### PR DESCRIPTION
**What this PR does**:

Fixes various issues in core
1. Issue where websockets for watching workflow executions would close because of k8s timeouts that were not handled
2. migration had missing initialization variable. This caused a crash when configmap changed.
3. Update configmap watcher to have it's own kube client that has no timeout as configmap watching has lots of timeouts, even on 3 minutes.

**Which issue(s) this PR fixes**:

Fixes onepanelio/core#798

**Special notes for your reviewer**:

**Checklist**

Please check if applies

- [ ] I have added/updated relevant unit tests
- [ ] I have added/updated relevant documentation

Required 

- [x] I accept to release these changes under the Apache 2.0 License   