### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push_dev_branch.yaml
+++ b/.github/workflows/push_dev_branch.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: onepanel/core
         tags: "latest"

--- a/.github/workflows/push_tag.yaml
+++ b/.github/workflows/push_tag.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: little-core-labs/get-git-tag@v3.0.1
         id: tagName
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: onepanel/core
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore